### PR TITLE
Updated plugins to 1.5 internal release version

### DIFF
--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -6,6 +6,6 @@ const (
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.stage.registry.redhat.com"
-	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.5.1-rc.1"
+	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.0-rc.2"
 	CatalogBranch                  = "v1.4.x"
 )

--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -6,6 +6,6 @@ const (
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.stage.registry.redhat.com"
-	Scope                          = "@redhat"
+	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/1.5.1-rc.1"
 	CatalogBranch                  = "v1.4.x"
 )

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -11,12 +11,12 @@ const OrchestratorBackend string = "orchestratorBackend"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.5.1-rc.1.tgz",
-			Integrity: "sha512-Pw1PfiGTLJzjRCINA3+s3zWy6L0WTmCZjOxa/iZlkpTN6ywAcmPD43wtWaFT5Hxhlr5NMa/2af291F4G1gAqcg==",
+			Package:   "backstage-plugin-orchestrator-1.5.0-rc.2.tgz",
+			Integrity: "sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.1-rc.1.tgz",
-			Integrity: "sha512-3YJYUFSaxNTQc5k40sfmVdibXFzbYEeiyBrGLOdcG6mB+Vdm90Hbv+isa6y3bbsK22juXbtAjsl39TtVGI1esg==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz",
+			Integrity: "sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==",
 		},
 	}
 

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -11,12 +11,12 @@ const OrchestratorBackend string = "orchestratorBackend"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator@1.4.0-rc.7",
-			Integrity: "sha512-Vclb+TIL8cEtf9G2nx0UJ+kMJnCGZuYG/Xcw0Otdo/fZGuynnoCaAZ6rHnt4PR6LerekHYWNUbzM3X+AVj5cwg==",
+			Package:   "backstage-plugin-orchestrator-1.5.1-rc.1.tgz",
+			Integrity: "sha512-Pw1PfiGTLJzjRCINA3+s3zWy6L0WTmCZjOxa/iZlkpTN6ywAcmPD43wtWaFT5Hxhlr5NMa/2af291F4G1gAqcg==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic@1.4.0-rc.7",
-			Integrity: "sha512-bxD0Au2V9BeUMcZBfNYrPSQ161vmZyKwm6Yik5keZZ09tenkc8fNjipwJsWVFQCDcAOOxdBAE0ibgHtddl3NKw==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.1-rc.1.tgz",
+			Integrity: "sha512-3YJYUFSaxNTQc5k40sfmVdibXFzbYEeiyBrGLOdcG6mB+Vdm90Hbv+isa6y3bbsK22juXbtAjsl39TtVGI1esg==",
 		},
 	}
 


### PR DESCRIPTION
Updated the plugins to pull from internal release repo: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/tag/v1.5.0-rc.2
```
https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.0-rc.2/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz
sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==

https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.0-rc.2/backstage-plugin-orchestrator-1.5.0-rc.2.tgz
sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
```

@mareklibra @ElaiShalevRH PTAL