### PR TITLE
Watch And Reconcile Subscription Resources

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ import (
 	argocdv1alpha1 "github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -63,6 +64,7 @@ func init() {
 	utilruntime.Must(tektonv1.AddToScheme(scheme))
 	utilruntime.Must(argocdv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(sonataapi.AddToScheme(scheme))
+	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -171,7 +171,11 @@ func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV 
 	logger.Info("Creating subscription object")
 
 	subscriptionObject := &v1alpha1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: subscriptionName},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      subscriptionName,
+			Labels:    AddLabel(),
+		},
 		Spec: &v1alpha1.SubscriptionSpec{
 			Channel:                channel,
 			InstallPlanApproval:    v1alpha1.ApprovalManual,

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -492,14 +492,14 @@ func (r *OrchestratorReconciler) reconcileSubscription(ctx context.Context, obje
 	subscriptionObject := object.(*olmv1alpha1.Subscription)
 
 	if subscriptionObject != nil && kube.CheckLabelExist(subscriptionObject.Labels) {
-		if subscriptionObject.Namespace == serverlessLogicOperatorNamespace {
+		if (subscriptionObject.Namespace == serverlessLogicOperatorNamespace) && (subscriptionObject.Name == serverlessLogicSubscriptionName) {
 			err := handleServerlessLogicOperatorInstallation(ctx, r.Client, r.OLMClient)
 			if err != nil && !apierrors.IsNotFound(err) {
 				log.Log.Error(err, "Error occurred when reconciling Serverless Logic subscription resources")
 				return nil
 			}
 		}
-		if subscriptionObject.Namespace == knativeOperatorNamespace {
+		if (subscriptionObject.Namespace == knativeOperatorNamespace) && (subscriptionObject.Name == knativeSubscriptionName) {
 			err := handleKNativeOperatorInstallation(ctx, r.Client, r.OLMClient)
 			if err != nil && !apierrors.IsNotFound(err) {
 				log.Log.Error(err, "Error occurred when reconciling Serverless subscription resources")

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -19,6 +19,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"strings"
 	"time"
 
@@ -152,8 +155,7 @@ func (r *OrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	serverlessWorkflowNamespace := orchestrator.Spec.PlatformConfig.Namespace
 
 	// handle serverless logic
-	serverlessLogicOperator := orchestrator.Spec.ServerlessLogicOperator
-	if err = r.reconcileServerlessLogic(ctx, serverlessLogicOperator, orchestrator); err != nil {
+	if err := r.reconcileServerlessLogic(ctx, orchestrator); err != nil {
 		if apierrors.IsNotFound(err) {
 			return ctrl.Result{Requeue: true, RequeueAfter: RequeueAfterTime}, nil
 		}
@@ -245,11 +247,11 @@ func (r *OrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 func (r *OrchestratorReconciler) reconcileServerlessLogic(
 	ctx context.Context,
-	serverlessLogicOperator orchestratorv1alpha2.ServerlessLogicOperator,
 	orchestrator *orchestratorv1alpha2.Orchestrator) error {
 
 	sfLogger := log.FromContext(ctx)
 	sfLogger.Info("Starting reconciliation for Serverless Logic")
+	serverlessLogicOperator := orchestrator.Spec.ServerlessLogicOperator
 
 	serverlessWorkflowNamespace := orchestrator.Spec.PlatformConfig.Namespace
 


### PR DESCRIPTION
The goal of this PR is to handle reconciliation of OSL and Serverless (Knative) subscription resources - RHDH is out of scope considering the up coming merging. The idea is that the operator watches each subscription resources and if there are changes, revert back to the desired subscription state. This will ensure that sub-component(OSL and Knative) subscription are in the validated and verified versions.

- Added Label when creating subscriptions
- Watch and register subscription API
- Added reconcile subscription handler
- Added checks to make sure we are reconciling OSL or Knative subscriptions that are created by the orchestrator operator

@ElaiShalevRH PTAL