### PR TITLE
Add Timestamp To Version Tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ endif
 # This is useful for CI or a project to utilize a specific version of the operator-sdk toolkit.
 OPERATOR_SDK_VERSION ?= v1.36.0
 # Image URL to use all building/pushing image targets
-IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
+TIMESTAMP ?= $(shell date +%Y-%m-%dT%H:%M:%S)
+IMG ?= $(IMAGE_TAG_BASE):$(VERSION):$(TIMESTAMP)
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 


### PR DESCRIPTION
Based on discussion with Chad, the mini releases will be suffixed with timestamp  for now, until the operator is considered stable. Updated the tag to have the timestamp.

@ElaiShalevRH  FYI