### PR TITLE
Refactor OLM Client

### DIFF
--- a/internal/controller/knative.go
+++ b/internal/controller/knative.go
@@ -44,7 +44,7 @@ const (
 	knativeSubscriptionStartingCSV = "serverless-operator.v1.35.0"
 )
 
-func handleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Clientset) error {
+func handleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {
 	knativeLogger := log.FromContext(ctx)
 
 	if _, err := kube.CheckNamespaceExist(ctx, client, knativeOperatorNamespace); err != nil {

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -65,7 +65,7 @@ func CreateNamespace(ctx context.Context, client client.Client, namespace string
 
 func InstallSubscriptionAndOperatorGroup(
 	ctx context.Context, client client.Client,
-	olmClientSet olmclientset.Clientset,
+	olmClientSet olmclientset.Interface,
 	operatorGroupName string,
 	subscription *v1alpha1.Subscription) error {
 
@@ -189,7 +189,7 @@ func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV 
 }
 
 func CheckSubscriptionExists(
-	ctx context.Context, olmClientSet olmclientset.Clientset,
+	ctx context.Context, olmClientSet olmclientset.Interface,
 	existingSubscription *v1alpha1.Subscription) (bool, *v1alpha1.Subscription, error) {
 	logger := log.FromContext(ctx)
 
@@ -245,7 +245,7 @@ func CleanUpNamespace(ctx context.Context, namespaceName string, client client.C
 	return nil
 }
 
-func CleanUpSubscriptionAndCSV(ctx context.Context, olmClientSet olmclientset.Clientset, subscription *v1alpha1.Subscription) error {
+func CleanUpSubscriptionAndCSV(ctx context.Context, olmClientSet olmclientset.Interface, subscription *v1alpha1.Subscription) error {
 	logger := log.FromContext(ctx)
 
 	subscriptionName := subscription.Name

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -62,7 +62,7 @@ const (
 // OrchestratorReconciler reconciles an Orchestrator object
 type OrchestratorReconciler struct {
 	client.Client
-	OLMClient olmclientset.Clientset
+	OLMClient olmclientset.Interface
 	Scheme    *runtime.Scheme
 	Recorder  record.EventRecorder
 }
@@ -522,7 +522,7 @@ func (r *OrchestratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err != nil {
 		return err
 	}
-	r.OLMClient = *olmClient
+	r.OLMClient = olmClient
 
 	o := ctrl.NewControllerManagedBy(mgr).
 		For(&orchestratorv1alpha2.Orchestrator{}).

--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -36,7 +36,7 @@ var ConfigMapNameAndConfigDataKey = map[string]string{
 	AppConfigRHDHDynamicPluginName: "dynamic-plugins.yaml",
 }
 
-func HandleRHDHOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Clientset) error {
+func HandleRHDHOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {
 	rhdhLogger := log.FromContext(ctx)
 
 	if _, err := kubeoperations.CheckNamespaceExist(ctx, client, rhdhOperatorNamespace); err != nil {

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -49,7 +49,7 @@ const (
 	knativeBrokerKind                      = "Broker"
 )
 
-func handleServerlessLogicOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Clientset) error {
+func handleServerlessLogicOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {
 	sfLogger := log.FromContext(ctx)
 
 	// create namespace for operator


### PR DESCRIPTION
Updated the function parameters to pass interface  instead of concrete class for the OLM client. That way we can as well pass the fake client when unit testing.