### PR TITLE
release 1.5 2025-03-13

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=orchestrator-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.38.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.36.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -20,10 +20,7 @@ metadata:
             },
             "platform": {
               "eventing": {
-                "broker": {
-                  "name": "my-knative",
-                  "namespace": "knative"
-                }
+                "broker": {}
               },
               "monitoring": {
                 "enabled": false
@@ -77,10 +74,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-12T00:26:35Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    createdAt: "2025-03-13T11:27:58Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.36.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
-  name: orchestrator-operator.v1.5.0-2025-03-11
+  name: orchestrator-operator.v1.5.0-2025-03-13
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -316,7 +313,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-2025-03-11
+                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-2025-03-13
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -404,4 +401,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.5.0-2025-03-11
+  version: 1.5.0-2025-03-13

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: orchestrator-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.36.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.5.0-2025-03-11
+  newTag: 1.5.0-2025-03-13


### PR DESCRIPTION
## Summary by Sourcery

Update the operator bundle and manager configuration to release version 1.5.0-2025-03-13. This includes updating the image tag, creation timestamp, and builder version in the cluster service version manifest, as well as updating the image tag in the manager kustomization file and the builder version in the bundle Dockerfile and annotations.

Build:
- Update the operator-sdk version to v1.36.0.
- Update the orchestrator-go-operator image tag to 1.5.0-2025-03-13 in the manager configuration.
- Update the orchestrator-go-operator image tag to 1.5.0-2025-03-13 in the cluster service version.