### PR TITLE
Existing RHDH Doc

### DIFF
--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,6 +239,12 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
+// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz
+// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-18T22:59:05Z"
+    createdAt: "2025-03-19T03:50:37Z"
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
   name: orchestrator-operator.v1.5.0-2025-03-18

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -3,6 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    orchestrator-backend-dynamic-integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz'
+    orchestrator-integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz'
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -4,6 +4,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
+    orchestrator-backend-dynamic-integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz'
+    orchestrator-integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz'
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -219,6 +219,8 @@ Include ArgoCD and Tekton Plugins if using OpenShift Gitops (ArgoCD) and OpenShi
         package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
       - disabled: false
         package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
 ```
 
 ### app-config ConfigMap

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -1,6 +1,6 @@
 # Prerequisites
 - RHDH 1.5 instance deployed with IDP configured (github, gitlab, ...)
-- For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.4.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
+- For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.5.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
 - A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
 
 # Installation steps
@@ -12,7 +12,7 @@ In 1.5, the Orchestrator infrastructure is installed using the Orchestrator Oper
    > Note: `${TARGET_NAMESPACE}` should be set to the desired namespace
 
     ```yaml
-    apiVersion: rhdh.redhat.com/v1alpha1
+    apiVersion: rhdh.redhat.com/v1alpha3
     kind: Orchestrator
     metadata:
       name: orchestrator-sample
@@ -273,12 +273,14 @@ Orchestrator software templates rely on the following tools:
 To import the Orchestrator software templates into the catalog via the Backstage UI, follow the instructions outlined in this [document](https://backstage.io/docs/features/software-templates/adding-templates).
 Register new templates into the catalog from the
 - Software templates for GitHub:
-    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/github-workflows/basic-workflow/template.yaml)
-    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/github-workflows/advanced-workflow/template.yaml)
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/advanced-workflow/template.yaml)
+    - [Convert workflow template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/convert-workflow-to-template/template.yaml)
 - Software templates for GitLab:
-    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml)
-    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml)
-- [Workflow resources (group and system)](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/entities/workflow-resources.yaml) (optional)
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml)
+    - [Convert workflow template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/convert-workflow-to-template/template.yaml)
+- [Workflow resources (group and system)](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/entities/workflow-resources.yaml) (optional)
 
 ## Plugin Versions
 
@@ -303,7 +305,7 @@ In the example output below, `orchestrator-backend-dynamic-integrity` is the int
 
 ### Upgrade plugin versions - WIP
 To perform an upgrade of the plugin versions, start by acquiring the new plugin version along with its associated integrity value.
-The following script is useful to obtain the required information for updating the plugin version, however, make sure to select plugin version compatible with the Orchestrator operator version (e.g. 1.4.x for both operator and plugins).
+The following script is useful to obtain the required information for updating the plugin version, however, make sure to select plugin version compatible with the Orchestrator operator version (e.g. 1.5.x for both operator and plugins).
 
 > Note: It is recommended to use the Orchestrator Operator default plugins
 

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -285,29 +285,21 @@ Register new templates into the catalog from the
 ### Identify Latest Supported Plugin Versions
 The versions of the plugins may undergo updates, leading to changes in their integrity values. The default plugin values in the Orchestrator CRD can be referenced to ensure that the latest supported plugin versions and integrity values are being utilized. The Orchestrator CRD default plugins can be identified with this command:
 ```bash
-oc get crd orchestrators.rhdh.redhat.com -o json | jq '.spec.versions[].schema.openAPIV3Schema.properties.spec.properties.rhdhPlugins.properties'
+oc get crd orchestrators.rhdh.redhat.com -o json | jq '.metadata.annotations | with_entries(select(.key | startswith("orchestrator")))' 
 ```
 
-In the example output below, `.properties.integrity.default` is the integrity value and `.properties.package.default` is the package name:
-```yaml
-  "orchestratorBackend": {
-    "description": "Orchestrator backend plugin information",
-    "properties": {
-      "integrity": {
-        "default": "sha512-2aOHDLFrGMAtyHFiyGZwVBZ9Op+TmKYUwfZxwoaGJ1s6JSy/0qgqineEEE0K3dn/f17XBUj+H1dwa5Al598Ugw==",
-        "description": "Package SHA integrity",
-        "type": "string"
-      },
-      "package": {
-        "default": "backstage-plugin-orchestrator-backend-dynamic@1.4.0",
-        "description": "Package name",
-        "type": "string"
-      }
-    },
-    "type": "object"
-  },
+In the example output below, `orchestrator-backend-dynamic-integrity` is the integrity value and `orchestrator-backend-dynamic-package` is the package name:
+```json
+{
+  "orchestrator-backend-dynamic-integrity": "sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==",
+  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz",
+  "orchestrator-integrity": "sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==",
+  "orchestrator-package": "@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz",
+  "orchestrator-scaffolder-backend-integrity": "sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==",
+  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz"
+}
 ```
-> Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0`)
+> Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0`)
 
 ### Upgrade plugin versions - WIP
 To perform an upgrade of the plugin versions, start by acquiring the new plugin version along with its associated integrity value.
@@ -321,6 +313,7 @@ The following script is useful to obtain the required information for updating t
 PLUGINS=(
   "@redhat/backstage-plugin-orchestrator"
   "@redhat/backstage-plugin-orchestrator-backend-dynamic"
+  "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic"
 )
 
 for PLUGIN_NAME in "${PLUGINS[@]}"
@@ -334,12 +327,16 @@ done
 A sample output should look like:
 ```
 Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator\n
-package: "@redhat/backstage-plugin-orchestrator@1.4.0"
-integrity: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+package: "@redhat/backstage-plugin-orchestrator@1.5.0"
+integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
 ---
 Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator-backend-dynamic\n
-package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0"
-integrity: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0"
+integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+---
+Retrieving latest version for plugin: @redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic\n
+package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.0"
+integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
 ---
 ```
 

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -1,0 +1,346 @@
+# Prerequisites
+- RHDH 1.5 instance deployed with IDP configured (github, gitlab, ...)
+- For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.4.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
+- A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
+
+# Installation steps
+
+## Install the Orchestrator Operator
+In 1.5, the Orchestrator infrastructure is installed using the Orchestrator Operator.
+1. Install the Orchestrator Operator 1.5 from OperatorHub.
+1. Create orchestrator resource (operand) instance - ensure `rhdh: installOperator: False` is set, e.g.
+   > Note: `${TARGET_NAMESPACE}` should be set to the desired namespace
+
+    ```yaml
+    apiVersion: rhdh.redhat.com/v1alpha1
+    kind: Orchestrator
+    metadata:
+      name: orchestrator-sample
+      namespace: ${TARGET_NAMESPACE}    # Replace with desired namespace
+    spec:
+      platform:
+        namespace: sonataflow-infra
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+             cpu: 250m
+             memory: 64Mi
+      postgres:
+        authSecret:
+          name: sonataflow-psql-postgresql
+          passwordKey: postgres-password
+          userKey: postgres-username
+        database: sonataflow
+        name: sonataflow-psql-postgresql
+        namespace: sonataflow-infra
+      rhdh:
+        installOperator: false
+    ```
+1. Verify resources and wait until they are running
+    1. From the console run the following command in order to get the necessary wait commands: \
+       `oc describe orchestrator orchestrator-sample -n ${TARGET_NAMESPACE} | grep -A 10 "Run the following commands to wait until the services are ready:"`
+
+       The command will return an output similar to the one below, which lists several oc wait commands. This depends on your specific cluster.
+       ```bash
+         oc wait -n openshift-serverless deploy/knative-openshift --for=condition=Available --timeout=5m
+         oc wait -n knative-eventing knativeeventing/knative-eventing --for=condition=Ready --timeout=5m
+         oc wait -n knative-serving knativeserving/knative-serving --for=condition=Ready --timeout=5m
+         oc wait -n openshift-serverless-logic deploy/logic-operator-rhel8-controller-manager --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra sonataflowplatform/sonataflow-platform --for=condition=Succeed --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-data-index-service --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-jobs-service --for=condition=Available --timeout=5m
+         oc get networkpolicy -n sonataflow-infra
+         ```
+    1. Copy and execute each command from the output in your terminal. These commands ensure that all necessary services and resources in your OpenShift environment are available and running correctly.
+    1. If any service does not become available, verify the logs for that service or consult [troubleshooting steps](https://www.rhdhorchestrator.io/main/docs/serverless-workflows/troubleshooting/).
+
+## Edit RHDH configuration
+As part of RHDH deployed resources, there are two primary ConfigMaps that require modification, typically found under the *rhdh-operator* namespace, or located in the same namespace as the Backstage CR.
+Before enabling the Orchestrator and Notifications plugins, please ensure that a secret that points to the target npmjs registry exists in the same RHDH namespace, e.g.:
+```
+cat <<EOF | oc apply -n $RHDH_NAMESPACE -f -
+apiVersion: v1
+data:
+  .npmrc: cmVnaXN0cnk9aHR0cHM6Ly9ucG0ucmVnaXN0cnkucmVkaGF0LmNvbQo=
+kind: Secret
+metadata:
+  name: dynamic-plugins-npmrc
+EOF
+```
+The value of `.data.npmrc` in the above example points to https://npm.registry.redhat.com. It should be included to consume plugins referenced in this document. If including plugins
+from a different NPM registry, the `.data.npmrc` value should be updated with the base64 encoded NPM registry. Example: https://registry.npmjs.org would be `aHR0cHM6Ly9yZWdpc3RyeS5ucG1qcy5vcmcK`.
+
+If there is a need to point to multiple registries, modify the content of the secret's data from:
+
+```yaml
+  stringData:
+    .npmrc: |
+      registry=https://npm.registry.redhat.com
+```
+to
+```yaml
+  stringData:
+    .npmrc: |
+      @redhat:registry=https://npm.registry.redhat.com
+      @<other-scope>:registry=<other-registry>
+```
+
+### Proxy configuration
+
+If you configured a proxy in your RHDH instance then you need to edit the `NO_PROXY` configuration. You need to add the namespaces where the workflows are deployed and also the namespace `sonataflow-infra`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,`.my-workflow-names
+pace`. Note the `.` before the namespace name.
+
+### dynamic-plugins ConfigMap
+This ConfigMap houses the configuration for enabling and configuring dynamic plugins in RHDH.
+
+To incorporate the Orchestrator plugins, append the following configuration to the **dynamic-plugins** ConfigMap:
+
+- Be sure to review [this section](#identify-latest-supported-plugin-versions) to determine the latest supported Orchestrator plugin `package:` and `integrity:` values, and update the dynamic-plugin ConfigMap entries accordingly. The samples in this document may not reflect the latest.
+- Additionally, ensure that the `dataIndexService.url` in the below configuration points to the service of the Data Index installed by the Orchestrator Operator.
+  By default it should point to `http://sonataflow-platform-data-index-service.sonataflow-infra`. Confirm the service by running this command:
+  ```bash
+  oc get svc -n sonataflow-infra sonataflow-platform-data-index-service -o jsonpath='http://{.metadata.name}.{.metadata.namespace}'
+  ```
+```yaml
+      - disabled: false
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz"
+        integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
+        pluginConfig:
+          orchestrator:
+            dataIndexService:
+              url: http://sonataflow-platform-data-index-service.sonataflow-infra
+      - disabled: false
+        package: "@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz"
+        integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-orchestrator:
+                appIcons:
+                  - importName: OrchestratorIcon
+                    module: OrchestratorPlugin
+                    name: orchestratorIcon
+                dynamicRoutes:
+                  - importName: OrchestratorPage
+                    menuItem:
+                      icon: orchestratorIcon
+                      text: Orchestrator
+                    module: OrchestratorPlugin
+                    path: /orchestrator
+      - disabled: false
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz"
+        integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==  
+        pluginConfig:
+          orchestrator:
+            dataIndexService:
+              url: http://sonataflow-platform-data-index-service.sonataflow-infra
+```
+
+To include the Notification Plugin append this configuration to the ConfigMap:
+- Be sure to review [this section](#identify-latest-supported-plugin-versions) to determine the latest supported Orchestrator plugin `package:` and `integrity:` values, and update the dynamic-plugin ConfigMap entries accordingly. The samples in this document may not reflect the latest.
+```yaml
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-signals"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+
+Optionally, include the `plugin-notifications-backend-module-email-dynamic` to fan-out notifications as emails.
+The environment variables below need to be provided to the RHDH instance (Or set the values directly in the ConfigMap).
+See more configuration options for the plugin [here](https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts).
+```yaml
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic"
+        pluginConfig:
+          notifications:
+            processors:
+              email:
+                transportConfig:
+                  transport: smtp
+                  hostname: ${NOTIFICATIONS_EMAIL_HOSTNAME}   # Use value or make variable accessible to Backstage
+                  port: 587
+                  secure: false
+                  username: ${NOTIFICATIONS_EMAIL_USERNAME}   # Use value or make variable accessible to Backstage
+                  password: ${NOTIFICATIONS_EMAIL_PASSWORD}   # Use value or make variable accessible to Backstage
+                sender: sender@mycompany.com
+                replyTo: no-reply@mycompany.com
+                broadcastConfig:
+                  receiver: "none"
+                concurrencyLimit: 10
+                cache:
+                  ttl:
+                    days: 1
+```
+
+Include ArgoCD and Tekton Plugins if using OpenShift Gitops (ArgoCD) and OpenShift Pipelines (Tekton) for Orchestrator Workflows
+```yaml
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+        pluginConfig:
+          kubernetes:
+            clusterLocatorMethods:
+            - clusters:
+              - authProvider: serviceAccount
+                name: Default Cluster
+                serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+                skipTLSVerify: true
+                url: ${K8S_CLUSTER_URL}
+              type: config
+            customResources:
+            - apiVersion: v1
+              group: tekton.dev
+              plural: pipelines
+            - apiVersion: v1
+              group: tekton.dev
+              plural: pipelineruns
+            - apiVersion: v1
+              group: tekton.dev
+              plural: taskruns
+            - apiVersion: v1
+              group: route.openshift.io
+              plural: routes
+            serviceLocatorMethod:
+              type: multiTenant
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+```
+
+### app-config ConfigMap
+This ConfigMap is used for configuring backstage. Please add/modify to include the following:
+- `${BACKEND_SECRET}` A static access token to enable the workflows to send notifications to RHDH (As described in the example below) or to invoke scaffolder actions (Or a different method based on this [doc](https://backstage.io/docs/auth/service-to-service-auth/)).
+- A static access token can be generated with this command `node -p 'require("crypto").randomBytes(24).toString("base64")'`
+- `${RHDH_ROUTE}` can be determined by running `oc get route -A -l app.kubernetes.io/name=backstage`
+- Define csp and cors
+- The `guest` provider is used in this example because backstage requires at least one provider to start (It is not required for Orchestrator). The guest provider should only be used for development purposes.
+```yaml
+    auth:
+      environment: development
+      providers:
+        guest:
+          dangerouslyAllowOutsideDevelopment: true
+    backend:
+      auth:
+        externalAccess:
+          - type: static
+            options:
+              token: ${BACKEND_SECRET} # Use value or make variable accessible to Backstage
+              subject: orchestrator
+          - type: legacy
+            options:
+              subject: legacy-default-config
+              secret: "pl4s3Ch4ng3M3"
+      baseUrl: https://${RHDH_ROUTE} # Use value or make variable accessible to Backstage
+      csp:
+        script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+        script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+        connect-src: ["'self'", 'http:', 'https:', 'data:']
+      cors:
+        origin: https://${RHDH_ROUTE} # Use value or make variable accessible to Backstage
+      # Include the database configuration if using the notifications plugin
+      database:
+        client: pg
+        connection:
+          password: ${POSTGRESQL_ADMIN_PASSWORD}
+          user: ${POSTGRES_USER}
+          host: ${POSTGRES_HOST}
+          port: ${POSTGRES_PORT}
+```
+> Note: `${BACKEND_SECRET}` and `${RHDH_ROUTE}` variables are not by default accessible by Backstage, so the values should be used directly in the ConfigMap or made accessible to Backstage.
+The `${POSTGRES_*}` variables *are* accessible by default, so they can be left in variable form.
+
+### Import Orchestrator's software templates
+Orchestrator software templates rely on the following tools:
+- Github or GitLab as the git repository system
+- Quay is the image registry
+- GitOps tools are OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton)
+
+To import the Orchestrator software templates into the catalog via the Backstage UI, follow the instructions outlined in this [document](https://backstage.io/docs/features/software-templates/adding-templates).
+Register new templates into the catalog from the
+- Software templates for GitHub:
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/github-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/github-workflows/advanced-workflow/template.yaml)
+- Software templates for GitLab:
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml)
+- [Workflow resources (group and system)](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.4.x/entities/workflow-resources.yaml) (optional)
+
+## Plugin Versions
+
+### Identify Latest Supported Plugin Versions
+The versions of the plugins may undergo updates, leading to changes in their integrity values. The default plugin values in the Orchestrator CRD can be referenced to ensure that the latest supported plugin versions and integrity values are being utilized. The Orchestrator CRD default plugins can be identified with this command:
+```bash
+oc get crd orchestrators.rhdh.redhat.com -o json | jq '.spec.versions[].schema.openAPIV3Schema.properties.spec.properties.rhdhPlugins.properties'
+```
+
+In the example output below, `.properties.integrity.default` is the integrity value and `.properties.package.default` is the package name:
+```yaml
+  "orchestratorBackend": {
+    "description": "Orchestrator backend plugin information",
+    "properties": {
+      "integrity": {
+        "default": "sha512-2aOHDLFrGMAtyHFiyGZwVBZ9Op+TmKYUwfZxwoaGJ1s6JSy/0qgqineEEE0K3dn/f17XBUj+H1dwa5Al598Ugw==",
+        "description": "Package SHA integrity",
+        "type": "string"
+      },
+      "package": {
+        "default": "backstage-plugin-orchestrator-backend-dynamic@1.4.0",
+        "description": "Package name",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+```
+> Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0`)
+
+### Upgrade plugin versions - WIP
+To perform an upgrade of the plugin versions, start by acquiring the new plugin version along with its associated integrity value.
+The following script is useful to obtain the required information for updating the plugin version, however, make sure to select plugin version compatible with the Orchestrator operator version (e.g. 1.4.x for both operator and plugins).
+
+> Note: It is recommended to use the Orchestrator Operator default plugins
+
+```bash
+#!/bin/bash
+
+PLUGINS=(
+  "@redhat/backstage-plugin-orchestrator"
+  "@redhat/backstage-plugin-orchestrator-backend-dynamic"
+)
+
+for PLUGIN_NAME in "${PLUGINS[@]}"
+do
+     echo "Retrieving latest version for plugin: $PLUGIN_NAME\n";
+     curl -s -q "https://npm.registry.redhat.com/${PLUGIN_NAME}/" | jq -r '.versions | keys_unsorted[-1] as $latest_version | .[$latest_version] | "package: \"\(.name)@\(.version)\"\nintegrity: \(.dist.integrity)"';
+     echo "---"
+done
+```
+
+A sample output should look like:
+```
+Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator\n
+package: "@redhat/backstage-plugin-orchestrator@1.4.0"
+integrity: sha512-vGGd9hUmDriEMmP2TfzLVa3JSnfot2Blg+aftDnu/lEphsY1s2gdA4Z5lCxUk7aobcKE6JO/f0sIl2jyxZ7ktw==
+---
+Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator-backend-dynamic\n
+package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.4.0"
+integrity: sha512-tS5cJGwjzP9esdTZvUFjw0O7+w9gGBI/+VvJrtqYJBDGXcEAq9iYixGk67ddQVW5eeUM7Tk1WqJlNj282aAWww==
+---
+```
+
+After editing the version and integrity values in the *dynamic-plugins* ConfigMap, the RHDH instance will be restarted automatically.

--- a/internal/controller/rhdh/rhdh_dynamic_plugin.go
+++ b/internal/controller/rhdh/rhdh_dynamic_plugin.go
@@ -130,6 +130,8 @@ plugins:
     disabled: false
   - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
     disabled: false
+  - package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+    disabled: false
   {{- if and (.NotificationEmailEnabled) (.NotificationEmailHostname) }}
   - package: ./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic
     disabled: false


### PR DESCRIPTION
Adding/Updating the doc for existing rhdh set up.

@y-first - I added the plugins in the `metadata.annotations` in the CRD.  And updated this [section](https://github.com/rhdhorchestrator/orchestrator-go-operator/commit/1808e64e6aea7350842c9277e38f2c20da2bafec) with the info: Will this make sense?

## Summary by Sourcery

Adds documentation for setting up the existing Red Hat Developer Hub (RHDH) with the Orchestrator, including steps for installing the Orchestrator Operator, configuring RHDH, and importing software templates.

Enhancements:
- Adds the plugins in the `metadata.annotations` in the CRD.
- Updates the orchestrator-operator.clusterserviceversion.yaml to update the creation timestamp.

Documentation:
- Adds a new document detailing the steps to set up the existing RHDH with the Orchestrator, covering prerequisites, installation, configuration, and software template import.
- Provides instructions for configuring the dynamic-plugins ConfigMap to incorporate Orchestrator and Notification plugins.
- Explains how to configure the app-config ConfigMap, including setting up authentication and defining Content Security Policy (CSP) and Cross-Origin Resource Sharing (CORS) policies.
- Details the process of importing Orchestrator's software templates, including those for GitHub and GitLab.
- Adds instructions to identify the latest supported plugin versions and upgrade them.