### PR TITLE
SSH + Git Fix

### DIFF
--- a/docs/gitops/README.md
+++ b/docs/gitops/README.md
@@ -143,7 +143,7 @@ ssh-keyscan github.com > github_ssh/known_hosts
 ```console
 echo "Host github.com
   HostName github.com
-  IdentityFile github_ssh/id_rsa" > github_ssh/config
+  IdentityFile ~/.ssh/id_rsa" > github_ssh/config
 ```
 
 - Create the secret that the Pipeline uses to store the SSH credentials:
@@ -188,7 +188,7 @@ ssh-keyscan <GitLabHost> > gitlab_ssh/known_hosts
 ```console
 echo "Host <GitLabHost>
 HostName <GitLabHost>
-IdentityFile gitlab_ssh/id_rsa" > gitlab_ssh/config
+IdentityFile ~/.ssh/id_rsa" > gitlab_ssh/config
 ```
 
 - Create the secret that the Pipeline uses to store the SSH credentials:

--- a/internal/controller/gitops/pipeline.go
+++ b/internal/controller/gitops/pipeline.go
@@ -115,7 +115,7 @@ func HandleTektonPipeline(client client.Client, ctx context.Context, gitOpsNames
 						{Name: "GIT_USER_NAME", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "The Orchestrator Tekton Pipeline"}},
 						{Name: "GIT_USER_EMAIL", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "rhdhorchestrator@redhat.com"}},
 						{Name: "USER_HOME", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "/home/git"}},
-						{Name: "GIT_SCRIPT", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: gitCloneScript}},
+						{Name: "GIT_SCRIPT", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: gitCloneGitOpsScript}},
 					},
 				},
 				{

--- a/internal/controller/gitops/scripts.go
+++ b/internal/controller/gitops/scripts.go
@@ -111,13 +111,11 @@ GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" 
 `
 
 const gitCloneScript = `eval "$(ssh-agent -s)"
-echo "${PARAM_USER_HOME}"
 ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" git clone $(params.gitUrl) workflow
 cd workflow
 `
 const gitCloneGitOpsScript = `eval "$(ssh-agent -s)"
-echo "${PARAM_USER_HOME}"
 ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
 GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" git clone $(params.gitOpsUrl) workflow-gitops
 `

--- a/internal/controller/gitops/scripts.go
+++ b/internal/controller/gitops/scripts.go
@@ -28,8 +28,7 @@ limitations under the License.
 
 package gitops
 
-const gitCLITaskScript = `
-#!/usr/bin/env sh
+const gitCLITaskScript = `#!/usr/bin/env sh
 set -eu
 
 if [ "${PARAM_VERBOSE}" = "true" ] ; then
@@ -64,8 +63,7 @@ fi
 # Make sure we don't add a trailing newline to the result!
 printf "%s" "$RESULT_SHA" > "$(results.commit.path)"
 `
-const flattenerTaskScript = `
-ROOT=/workspace/workflow
+const flattenerTaskScript = `ROOT=/workspace/workflow
 TARGET=flat
 mkdir -p flat
 
@@ -87,25 +85,21 @@ ls flat/$(params.workflowId)
 curl -L https://raw.githubusercontent.com/rhdhorchestrator/serverless-workflows/main/pipeline/workflow-builder.Dockerfile -o flat/workflow-builder.Dockerfile
 `
 
-const buildManifestTaskScript = `
-microdnf install -y tar gzip
+const buildManifestTaskScript = `microdnf install -y tar gzip
 KN_CLI_URL="https://developers.redhat.com/content-gateway/file/pub/cgw/serverless-logic/1.35.0/kn-workflow-linux-amd64.tar.gz"
 curl -L "$KN_CLI_URL" | tar -xz --no-same-owner && chmod +x kn-workflow-linux-amd64 && mv kn-workflow-linux-amd64 kn-workflow
 ./kn-workflow gen-manifest --namespace ""
 `
 
-const buildGitOpsTaskScript = `
-cp $(workspaces.workflow-source.path)/flat/$(params.workflowId)/manifests/* kustomize/base
+const buildGitOpsTaskScript = `cp $(workspaces.workflow-source.path)/flat/$(params.workflowId)/manifests/* kustomize/base
 microdnf install -y findutils && microdnf clean all
 cd kustomize
 ./updater.sh $(params.workflowId) $(params.imageTag)
 `
 
-const gitScript = `
-WORKFLOW_COMMIT=$(tasks.fetch-workflow.results.commit)
-
+const gitScript = `WORKFLOW_COMMIT=$(tasks.fetch-workflow.results.commit)
 eval "$(ssh-agent -s)"
-ssh-add "${PARAM_USER_HOME}/.ssh/id_rsa"
+ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
 
 cd workflow-gitops
 git add .
@@ -113,12 +107,17 @@ git diff
 # TODO: create PR
 git commit -m "Deployment for workflow commit $WORKFLOW_COMMIT from $(params.gitUrl)"
 # TODO: parametrize branch
-git push origin main
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" git push origin main
 `
 
-const gitCloneScript = `
-eval "$(ssh-agent -s)"
-ssh-add "${PARAM_USER_HOME}/.ssh/id_rsa"
-git clone $(params.gitUrl) workflow
+const gitCloneScript = `eval "$(ssh-agent -s)"
+echo "${PARAM_USER_HOME}"
+ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" git clone $(params.gitUrl) workflow
 cd workflow
+`
+const gitCloneGitOpsScript = `eval "$(ssh-agent -s)"
+echo "${PARAM_USER_HOME}"
+ssh-add "${PARAM_USER_HOME}"/.ssh/id_rsa
+GIT_SSH_COMMAND="ssh -o UserKnownHostsFile=${PARAM_USER_HOME}/.ssh/known_hosts" git clone $(params.gitOpsUrl) workflow-gitops
 `


### PR DESCRIPTION
During the workflow pipeline run, git clone throws an errror where it could not verify the host key. From the behaviour, it seems by default ssh is looking for the Github host keys inside `~/.ssh/known_hosts.d/%k` instead of `/home/git/.ssh/known_hosts` (where the keys are) because in `/etc/ssh/ssh_config`, `UserKnownHostsFile` is set to `~/.ssh/known_hosts.d/%k`. For now, we explictly set the GIT_SSH_COMMAND and force ssh to look in the correct `known_host` file.

@ElaiShalevRH , @y-first PTAL

## Summary by Sourcery

Fix SSH host key verification issue during Git clone operations in the workflow pipeline

Bug Fixes:
- Resolve Git clone host key verification error by explicitly setting the UserKnownHostsFile path in the SSH command

Enhancements:
- Modify Git clone and push scripts to use a specific known_hosts file location

Chores:
- Add debug echo statement to print user home directory