### PR TITLE
Pinned RHDH to 1.5.1

### DIFF
--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -24,9 +24,9 @@ const (
 	rhdhCRDName                       = "backstages.rhdh.redhat.com"
 	rhdhReplica                 int32 = 1
 	rhdhSubscriptionName              = "rhdh"
-	rhdhSubscriptionChannel           = "fast-1.4"
+	rhdhSubscriptionChannel           = "fast-1.5"
 	rhdhOperatorNamespace             = "rhdh-operator"
-	rhdhSubscriptionStartingCSV       = "rhdh-operator.v1.4.1"
+	rhdhSubscriptionStartingCSV       = "rhdh-operator.v1.5.1"
 )
 
 var ConfigMapNameAndConfigDataKey = map[string]string{


### PR DESCRIPTION
Update RHDH CSV to 1.5.1 and channel to 1.5

@ElaiShalevRH @y-first FYI

## Summary by Sourcery

Enhancements:
- Update RHDH subscription channel from 1.4 to 1.5 to align with the new operator version