### PR TITLE
Operator Release for 1.5.0-2025-04-01

### DIFF
--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-03-25T02:46:31Z"
+    createdAt: "2025-04-01T07:02:01Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.5.0-2025-03-24
+  name: orchestrator-operator.v1.5.0-2025-04-01
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -325,7 +325,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-2025-03-24
+                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-2025-04-01
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -413,4 +413,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.5.0-2025-03-24
+  version: 1.5.0-2025-04-01

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.5.0-2025-03-18
+  newTag: 1.5.0-2025-04-01


### PR DESCRIPTION
@ElaiShalevRH

## Summary by Sourcery

Chores:
- Bump operator version and image tag to 1.5.0-2025-04-01