### PR TITLE
making operator point to 1.5 templates

### DIFF
--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -7,5 +7,5 @@ const (
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.stage.registry.redhat.com"
 	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.0-rc.2"
-	CatalogBranch                  = "main"
+	CatalogBranch                  = "v1.5.x"
 )


### PR DESCRIPTION
This PR updates the catalog branch to be v1.5.x instead of main. And closes this bug:
https://issues.redhat.com/browse/FLPATH-2192

## Summary by Sourcery

Bug Fixes:
- Resolve issue FLPATH-2192 by updating the catalog branch to the correct version