### PR TITLE
Update Condition Status + SFCP Platform Reference Name

### DIFF
--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -428,12 +428,10 @@ func (r *OrchestratorReconciler) handleCleanUp(ctx context.Context, orchestrator
 func (r *OrchestratorReconciler) UpdateStatus(ctx context.Context, orchestrator *orchestratorv1alpha2.Orchestrator, phase orchestratorv1alpha2.OrchestratorPhase, condition metav1.Condition) error {
 	logger := log.FromContext(ctx)
 
-	patch := client.MergeFrom(orchestrator.DeepCopy())
 	orchestrator.Status.Phase = phase
 	meta.SetStatusCondition(&orchestrator.Status.Conditions, condition)
 
-	//err := r.Status().Update(ctx, orchestrator)
-	err := r.Status().Patch(ctx, orchestrator, patch)
+	err := r.Status().Update(ctx, orchestrator)
 	if err != nil {
 		logger.Error(err, "Failed to update Orchestrator status")
 		return err

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -47,6 +47,7 @@ const (
 	serverlessLogicSubscriptionStartingCSV = "logic-operator-rhel8.v1.35.0"
 	knativeBrokerAPIVersion                = "eventing.knative.dev/v1"
 	knativeBrokerKind                      = "Broker"
+	sonataFlowPlatformReference            = "sonataflow-platform"
 )
 
 // handleServerlessLogicOperatorInstallation performs operator installation for the OSL operand
@@ -175,9 +176,8 @@ func handleSonataFlowClusterCR(ctx context.Context, client client.Client, crName
 					Kind:       sonataFlowClusterPlatformKind,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      sonataFlowClusterPlatformCRName,
-					Namespace: namespace,
-					Labels:    kube.AddLabel(),
+					Name:   sonataFlowClusterPlatformCRName,
+					Labels: kube.AddLabel(),
 				},
 				Spec: getSonataFlowClusterSpec(namespace),
 			}
@@ -199,7 +199,7 @@ func handleSonataFlowClusterCR(ctx context.Context, client client.Client, crName
 func getSonataFlowClusterSpec(namespace string) sonataapi.SonataFlowClusterPlatformSpec {
 	return sonataapi.SonataFlowClusterPlatformSpec{
 		PlatformRef: sonataapi.SonataFlowPlatformRef{
-			Name:      sonataFlowClusterPlatformCRName,
+			Name:      sonataFlowPlatformReference,
 			Namespace: namespace,
 		},
 	}


### PR DESCRIPTION
Related to bug tickets:
[FLPATH-2244](https://issues.redhat.com/browse/FLPATH-2244) - Changed `SonataflowClusterPlatform` to Point to the correct Platform Reference which is `sonataflow-platform`.
[FLPATH-2149](https://issues.redhat.com/browse/FLPATH-2149) - Refactored status update to show completed reconciliation.

## Summary by Sourcery

Update Orchestrator status condition and SonataFlow platform reference to improve reconciliation and platform configuration

Bug Fixes:
- Fixed the SonataFlowClusterPlatform reference to point to the correct platform name 'sonataflow-platform'
- Corrected the status update mechanism to properly reflect reconciliation completion

Enhancements:
- Modified status condition type from 'Degrading' to 'Completed'
- Updated status update method to use patch instead of direct update
- Removed unnecessary namespace specification for SonataFlow Cluster CR