### PR TITLE
Remove OSL Resources

### DIFF
--- a/internal/controller/gitops/argocd.go
+++ b/internal/controller/gitops/argocd.go
@@ -64,7 +64,7 @@ func handleArgoCDProject(gitOpsNamespace string, client client.Client, ctx conte
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      argoCDCRName,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: argocdv1alpha1.AppProjectSpec{
 			Destinations: []argocdv1alpha1.ApplicationDestination{

--- a/internal/controller/gitops/pipeline.go
+++ b/internal/controller/gitops/pipeline.go
@@ -43,7 +43,7 @@ func HandleTektonPipeline(client client.Client, ctx context.Context, gitOpsNames
 		ObjectMeta: ctrl.ObjectMeta{
 			Name:      pipelineName,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: tektonv1.PipelineSpec{
 			Description: "This pipeline clones a git repo, builds a Docker image with Kaniko, and pushes it to a registry",

--- a/internal/controller/gitops/tasks.go
+++ b/internal/controller/gitops/tasks.go
@@ -99,7 +99,7 @@ func createGitCLITaskObject(gitOpsNamespace string) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      gitCLITask,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 			Annotations: map[string]string{
 				"tekton.dev/pipelines.minVersion": "0.21.0",
 				"tekton.dev/categories":           "Git",
@@ -223,7 +223,7 @@ func createFlattenerTaskObject(gitOpsNamespace string) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      flattenerTask,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: tektonv1.TaskSpec{
 			Workspaces: []tektonv1.WorkspaceDeclaration{
@@ -268,7 +268,7 @@ func createBuildManifestTaskObject(gitOpsNamespace string) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildManifestTask,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: tektonv1.TaskSpec{
 			Workspaces: []tektonv1.WorkspaceDeclaration{
@@ -304,7 +304,7 @@ func createBuildGitOpsTaskObject(gitOpsNamespace string) *tektonv1.Task {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      buildGitOpsTask,
 			Namespace: gitOpsNamespace,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: tektonv1.TaskSpec{
 			Workspaces: []tektonv1.WorkspaceDeclaration{

--- a/internal/controller/knative.go
+++ b/internal/controller/knative.go
@@ -160,7 +160,7 @@ func handleKnativeEventingCR(ctx context.Context, client client.Client) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      knativeEventingNamespacedName,
 			Namespace: knativeEventingNamespacedName,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: knative.KnativeEventingSpec{},
 	}
@@ -205,7 +205,7 @@ func handleKnativeServingCR(ctx context.Context, client client.Client) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      knativeServingNamespacedName,
 			Namespace: knativeServingNamespacedName,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: knative.KnativeServingSpec{},
 	}

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -62,7 +62,7 @@ func CreateNamespace(ctx context.Context, client client.Client, namespace string
 	nsLogger := log.FromContext(ctx)
 	nsLogger.Info("Creating namespace", "Namespace", namespace)
 	// create new namespace
-	newNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: AddLabel()}}
+	newNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace, Labels: GetOrchestratorLabel()}}
 	err := client.Create(ctx, newNamespace)
 	if err != nil {
 		nsLogger.Error(err, "Error occurred when creating namespace", "Namespace", namespace)
@@ -182,7 +182,7 @@ func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV 
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      subscriptionName,
-			Labels:    AddLabel(),
+			Labels:    GetOrchestratorLabel(),
 		},
 		Spec: &v1alpha1.SubscriptionSpec{
 			Channel:                channel,
@@ -297,7 +297,7 @@ func CleanUpSubscriptionAndCSV(ctx context.Context, olmClientSet olmclientset.In
 	return err
 }
 
-func AddLabel() map[string]string {
+func GetOrchestratorLabel() map[string]string {
 	return map[string]string{
 		CreatedByLabelKey: CreatedByLabelValue,
 	}

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -342,15 +342,18 @@ func RemoveCustomResourcesInNamespace[T client.ObjectList, I client.Object](ctx 
 
 	// List the CRs
 	if err := k8client.List(ctx, objList, listOptions...); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Custom resource not found in namespace", "NS", namespace)
+			return nil
+		}
 		logger.Error(err, "Error occurred when listing resources")
-		return nil
+		return err
 	}
 	for _, item := range getItems(objList) {
 		if err := k8client.Delete(ctx, item); err != nil {
-			logger.Error(err, "failed to delete resource %s: %w", item.GetName(), err)
+			logger.Error(err, "Error occurred when to delete resource", "CR-Name", item.GetName())
 			return err
 		}
 	}
-
 	return nil
 }

--- a/internal/controller/kube/kube_operations_test.go
+++ b/internal/controller/kube/kube_operations_test.go
@@ -431,12 +431,7 @@ func TestRemoveCustomResourcesInNamespace(t *testing.T) {
 			crObj:     &sonataapi.SonataFlowClusterPlatform{},
 			crObjList: &sonataapi.SonataFlowClusterPlatformList{},
 			getItems: func(list client.ObjectList) []client.Object {
-				typedList := list.(*sonataapi.SonataFlowClusterPlatformList)
-				objs := make([]client.Object, len(typedList.Items))
-				for i := range typedList.Items {
-					objs[i] = &typedList.Items[i]
-				}
-				return objs
+				return []client.Object{}
 			},
 			expectedError: nil,
 		},

--- a/internal/controller/kube/kube_operations_test.go
+++ b/internal/controller/kube/kube_operations_test.go
@@ -42,7 +42,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      subscriptionName,
 			Namespace: orchestratorNamespace,
-			Labels:    AddLabel(),
+			Labels:    GetOrchestratorLabel(),
 		},
 		Spec: &v1alpha1.SubscriptionSpec{
 			Channel:                "channel",
@@ -113,7 +113,7 @@ func TestCreateNamespace(t *testing.T) {
 		{
 			name:          "Create namespace with error",
 			namespace:     "fake-namespace",
-			namespaceObj:  &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "fake-namespace", Labels: AddLabel()}},
+			namespaceObj:  &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "fake-namespace", Labels: GetOrchestratorLabel()}},
 			expectedError: apierrors.NewAlreadyExists(schema.GroupResource{}, "fake-namespace"),
 		},
 	}
@@ -293,7 +293,7 @@ func TestCleanUpNamespace(t *testing.T) {
 	utilruntime.Must(corev1.AddToScheme(scheme))
 
 	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: orchestratorNamespace, Labels: AddLabel()},
+		ObjectMeta: metav1.ObjectMeta{Name: orchestratorNamespace, Labels: GetOrchestratorLabel()},
 	}
 	t.Run("Clean up namespace with no error", func(t *testing.T) {
 		fakeClientWithoutNS := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
@@ -308,7 +308,7 @@ func TestAddLabel(t *testing.T) {
 	}
 
 	t.Run("Add label", func(t *testing.T) {
-		labelMap := AddLabel()
+		labelMap := GetOrchestratorLabel()
 		assert.NotNil(t, labelMap, "Expected labelMap to not be nil")
 		assert.Equal(t, expectedLabels, labelMap, "Expected labelMap to match expectedLabels")
 		assert.Equal(t, len(expectedLabels), len(labelMap), "Expected labelMap to have the same length")

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -48,7 +48,7 @@ func handleNetworkPolicy(client client.Client, ctx context.Context,
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      NetworkPolicyName,
 				Namespace: networkAndServerlessWorkflowNamespace,
-				Labels:    kubeoperations.AddLabel(),
+				Labels:    kubeoperations.GetOrchestratorLabel(),
 			},
 			Spec: networkingv1.NetworkPolicySpec{
 				// This policy applies to all pods within the namespace where the policy is defined

--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -61,7 +61,7 @@ func TestHandleNetworkPolicy(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      allowRHDHToSonataflowWorkflows,
 						Namespace: testNamespace,
-						Labels:    kubeoperations.AddLabel(),
+						Labels:    kubeoperations.GetOrchestratorLabel(),
 					},
 					Spec: networkingv1.NetworkPolicySpec{
 						PodSelector: metav1.LabelSelector{},

--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -112,7 +112,7 @@ func CreateRHDHSecret(secretNamespace string, ctx context.Context, client client
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      RegistrySecretName,
 					Namespace: secretNamespace,
-					Labels:    kubeoperations.AddLabel(),
+					Labels:    kubeoperations.GetOrchestratorLabel(),
 				},
 				Type: corev1.SecretTypeOpaque,
 				StringData: map[string]string{
@@ -168,7 +168,7 @@ func HandleRHDHCR(
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      rhdhName,
 					Namespace: rhdhConfig.Namespace,
-					Labels:    kubeoperations.AddLabel(),
+					Labels:    kubeoperations.GetOrchestratorLabel(),
 				},
 				Spec: rhdhv1alpha3.BackstageSpec{
 					Application: &rhdhv1alpha3.Application{
@@ -243,7 +243,7 @@ func CreateConfigMap(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    kubeoperations.AddLabel(),
+			Labels:    kubeoperations.GetOrchestratorLabel(),
 		},
 		Data: map[string]string{
 			configDataKey: configValue,

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -16,6 +16,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	sonataapi "github.com/apache/incubator-kie-tools/packages/sonataflow-operator/api/v1alpha08"
@@ -177,7 +178,7 @@ func handleSonataFlowClusterCR(ctx context.Context, client client.Client, crName
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   sonataFlowClusterPlatformCRName,
-					Labels: kube.AddLabel(),
+					Labels: kube.GetOrchestratorLabel(),
 				},
 				Spec: getSonataFlowClusterSpec(namespace),
 			}
@@ -231,7 +232,7 @@ func handleSonataFlowPlatformCR(
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      sonataFlowPlatformCRName,
 					Namespace: namespace,
-					Labels:    kube.AddLabel(),
+					Labels:    kube.GetOrchestratorLabel(),
 				},
 				Spec: getSonataFlowPlatformSpec(ctx, orchestrator),
 			}


### PR DESCRIPTION
Related to bug [FLPATH-2164](https://issues.redhat.com/browse/FLPATH-2164)

## Summary by Sourcery

Remove and refactor Orchestrator Service Logic (OSL) resources management, replacing AddLabel() with GetOrchestratorLabel() and introducing a new method to remove custom resources

Enhancements:
- Introduced a generic method RemoveCustomResourcesInNamespace for removing custom resources
- Refactored label-related methods to use a more descriptive name GetOrchestratorLabel()

Tests:
- Added test cases for RemoveCustomResourcesInNamespace method
- Updated existing test cases to use new GetOrchestratorLabel() method

Chores:
- Updated multiple files to use the new GetOrchestratorLabel() method instead of AddLabel()
- Simplified resource cleanup logic in various controllers