### PR TITLE
Added Knative Unit tests, moved to new package

### DIFF
--- a/internal/controller/knative/knative.go
+++ b/internal/controller/knative/knative.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package knative
+
+import (
+	"context"
+	"reflect"
+
+	olmclientset "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/kube"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	Knative "knative.dev/operator/pkg/apis/operator/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	KnativeAPIVersion              = "operator.knative.dev/v1beta1"
+	KnativeServingKind             = "KnativeServing"
+	KnativeServingNamespacedName   = "knative-serving"
+	KnativeEventingKind            = "KnativeEventing"
+	KnativeEventingNamespacedName  = "knative-eventing"
+	KnativeEventingCRDName         = "knativeeventings.operator.knative.dev"
+	KnativeServingCRDName          = "knativeservings.operator.knative.dev"
+	KnativeOperatorGroupName       = "serverless-operator-group"
+	KnativeSubscriptionName        = "serverless-operator"
+	KnativeOperatorNamespace       = "openshift-serverless"
+	KnativeSubscriptionChannel     = "stable"
+	KnativeSubscriptionStartingCSV = "serverless-operator.v1.35.0"
+)
+
+func HandleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {
+	KnativeLogger := log.FromContext(ctx)
+
+	if _, err := kube.CheckNamespaceExist(ctx, client, KnativeOperatorNamespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			KnativeLogger.Info("Creating namespace", "NS", KnativeOperatorNamespace)
+			if err := kube.CreateNamespace(ctx, client, KnativeOperatorNamespace); err != nil {
+				KnativeLogger.Error(err, "Error occurred when creating namespace", "NS", KnativeOperatorNamespace)
+				return nil
+			}
+		} else {
+			KnativeLogger.Error(err, "Error occurred when checking namespace exist", "NS", KnativeOperatorNamespace)
+			return err
+		}
+	}
+
+	serverlessSubscription := kube.CreateSubscriptionObject(
+		KnativeSubscriptionName,
+		KnativeOperatorNamespace,
+		KnativeSubscriptionChannel,
+		KnativeSubscriptionStartingCSV)
+
+	// check if subscription exists
+	subscriptionExists, existingSubscription, err := kube.CheckSubscriptionExists(ctx, olmClientSet, serverlessSubscription)
+	if err != nil {
+		KnativeLogger.Error(err, "Error occurred when checking subscription exists", "SubscriptionName", KnativeSubscriptionName)
+		return err
+	}
+	if !subscriptionExists {
+		if err := kube.InstallSubscriptionAndOperatorGroup(
+			ctx, client, olmClientSet,
+			KnativeOperatorGroupName, serverlessSubscription); err != nil {
+			KnativeLogger.Error(err, "Error occurred when installing operator", "SubscriptionName", KnativeSubscriptionName)
+			return err
+		}
+		KnativeLogger.Info("Operator successfully installed", "SubscriptionName", KnativeSubscriptionName)
+	} else {
+		// Compare the current and desired state
+		if !reflect.DeepEqual(existingSubscription.Spec, serverlessSubscription.Spec) {
+			// Update the existing subscription with the new Spec
+			existingSubscription.Spec = serverlessSubscription.Spec
+			if err := client.Update(ctx, existingSubscription); err != nil {
+				KnativeLogger.Error(err, "Error occurred when updating subscription spec", "SubscriptionName", KnativeSubscriptionName)
+				return err
+			}
+			KnativeLogger.Info("Successfully updated updating subscription spec", "SubscriptionName", KnativeSubscriptionName)
+		}
+	}
+
+	// approve install plan
+	if existingSubscription.Status.InstallPlanRef != nil && existingSubscription.Status.CurrentCSV == KnativeSubscriptionStartingCSV {
+		installPlanName := existingSubscription.Status.InstallPlanRef.Name
+		if err := kube.ApproveInstallPlan(client, ctx, installPlanName, existingSubscription.Namespace); err != nil {
+			KnativeLogger.Error(err, "Error occurred while approving install plan for subscription", "SubscriptionName", installPlanName)
+			return err
+		}
+	}
+
+	return nil
+}
+
+func HandleKnativeCR(ctx context.Context, client client.Client) error {
+	KnativeLogger := log.FromContext(ctx)
+	KnativeLogger.Info("Handling Serverless Custom Resources...")
+
+	// subscription exists; check if CRD exists for Knative eventing;
+	if err := kube.CheckCRDExists(ctx, client, KnativeEventingCRDName); err != nil {
+		if apierrors.IsNotFound(err) {
+			KnativeLogger.Info("CRD resource not found or ready", "SubscriptionName", KnativeSubscriptionName)
+			return err
+		}
+		KnativeLogger.Error(err, "Error occurred when retrieving CRD", "CRD", KnativeEventingCRDName)
+		return err
+	}
+	// CRD exists; check and handle Knative eventing CR
+	if err := HandleKnativeEventingCR(ctx, client); err != nil {
+		KnativeLogger.Error(err, "Error occurred when creating Knative EventingCR", "CR-Name", KnativeEventingNamespacedName)
+		return err
+	}
+
+	// subscription exists; check if Knative serving CRD exists;
+	if err := kube.CheckCRDExists(ctx, client, KnativeServingCRDName); err != nil {
+		if apierrors.IsNotFound(err) {
+			KnativeLogger.Info("CRD resource not found or ready", "SubscriptionName", KnativeSubscriptionName)
+			return err
+		}
+		KnativeLogger.Error(err, "Error occurred when retrieving CRD", "CRD", KnativeServingCRDName)
+		return err
+	}
+	// CRD exist; check and handle Knative serving CR
+	if err := HandleKnativeServingCR(ctx, client); err != nil {
+		KnativeLogger.Error(err, "Error occurred when creating Knative ServingCR", "CR-Name", KnativeServingNamespacedName)
+		return err
+	}
+	return nil
+}
+
+func HandleKnativeEventingCR(ctx context.Context, client client.Client) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Handling K-Native Eventing CR")
+
+	// check namespace exist; else create namespace
+	namespaceExist, _ := kube.CheckNamespaceExist(ctx, client, KnativeEventingNamespacedName)
+	if !namespaceExist {
+		if err := kube.CreateNamespace(ctx, client, KnativeEventingNamespacedName); err != nil {
+			logger.Error(err, "Error occurred when creating namespace", "NS", KnativeEventingNamespacedName)
+			return err
+		}
+	}
+
+	desiredKnEventingCR := &Knative.KnativeEventing{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: KnativeAPIVersion,
+			Kind:       KnativeEventingKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KnativeEventingNamespacedName,
+			Namespace: KnativeEventingNamespacedName,
+			Labels:    kube.AddLabel(),
+		},
+		Spec: Knative.KnativeEventingSpec{},
+	}
+	currentKnEventingCR := &Knative.KnativeEventing{}
+
+	// check CR exists
+	err := client.Get(ctx, types.NamespacedName{Name: KnativeEventingNamespacedName, Namespace: KnativeEventingNamespacedName}, currentKnEventingCR)
+
+	if err != nil {
+		// CR does not exist. Create CR
+		if apierrors.IsNotFound(err) {
+			if err = client.Create(ctx, desiredKnEventingCR); err != nil {
+				logger.Error(err, "Error occurred when creating CR resource", "CR-Name", desiredKnEventingCR.Name)
+			}
+			logger.Info("Successfully created Knative Eventing resource", "CR-Name", desiredKnEventingCR.Name)
+			return nil
+		}
+		logger.Error(err, "Error occurred when checking CR resource exist", "CR-Name", desiredKnEventingCR.Name)
+		return err
+	}
+	return nil
+}
+
+func HandleKnativeServingCR(ctx context.Context, client client.Client) error {
+	logger := log.FromContext(ctx)
+	logger.Info("Handling K-Native Serving CR")
+
+	// check namespace exist; else create namespace
+	namespaceExist, _ := kube.CheckNamespaceExist(ctx, client, KnativeServingNamespacedName)
+	if !namespaceExist {
+		if err := kube.CreateNamespace(ctx, client, KnativeServingNamespacedName); err != nil {
+			logger.Error(err, "Error occurred when creating namespace", "NS", KnativeEventingNamespacedName)
+			return err
+		}
+	}
+
+	desiredKnServingCR := &Knative.KnativeServing{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: KnativeAPIVersion,
+			Kind:       KnativeServingKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KnativeServingNamespacedName,
+			Namespace: KnativeServingNamespacedName,
+			Labels:    kube.AddLabel(),
+		},
+		Spec: Knative.KnativeServingSpec{},
+	}
+	currentKnServingCR := &Knative.KnativeServing{}
+
+	// check CR exists
+	err := client.Get(ctx, types.NamespacedName{Name: KnativeServingNamespacedName, Namespace: KnativeServingNamespacedName}, currentKnServingCR)
+
+	if err != nil {
+		// CR does not exist. Create CR
+		if apierrors.IsNotFound(err) {
+			if err = client.Create(ctx, desiredKnServingCR); err != nil {
+				logger.Error(err, "Error occurred when creating CR resource", "CR-Name", desiredKnServingCR.Name)
+			}
+			logger.Info("Successfully created Knative Eventing resource", "CR-Name", desiredKnServingCR.Name)
+			return nil
+		}
+		logger.Error(err, "Error occurred when checking CR resource exist", "CR-Name", desiredKnServingCR.Name)
+		return err
+	}
+	return nil
+}
+
+func HandleKnativeCleanUp(ctx context.Context, client client.Client) error {
+	logger := log.FromContext(ctx)
+	// remove all namespace
+	if err := kube.CleanUpNamespace(ctx, KnativeEventingNamespacedName, client); err != nil {
+		logger.Error(err, "Error occurred when deleting namespace", "NS", KnativeEventingNamespacedName)
+		return err
+	}
+	if err := kube.CleanUpNamespace(ctx, KnativeServingNamespacedName, client); err != nil {
+		logger.Error(err, "Error occurred when deleting namespace", "NS", KnativeServingNamespacedName)
+		return err
+	}
+
+	// remove operator namespace
+	if err := kube.CleanUpNamespace(ctx, KnativeOperatorNamespace, client); err != nil {
+		logger.Error(err, "Error occurred when deleting namespace", "NS", KnativeOperatorNamespace)
+		return err
+	}
+
+	return nil
+}

--- a/internal/controller/knative/knative.go
+++ b/internal/controller/knative/knative.go
@@ -53,11 +53,8 @@ func HandleKNativeOperatorInstallation(ctx context.Context, client client.Client
 			KnativeLogger.Info("Creating namespace", "NS", KnativeOperatorNamespace)
 			if err := kube.CreateNamespace(ctx, client, KnativeOperatorNamespace); err != nil {
 				KnativeLogger.Error(err, "Error occurred when creating namespace", "NS", KnativeOperatorNamespace)
-				return nil
+				return err
 			}
-		} else {
-			KnativeLogger.Error(err, "Error occurred when checking namespace exist", "NS", KnativeOperatorNamespace)
-			return err
 		}
 	}
 
@@ -163,7 +160,7 @@ func HandleKnativeEventingCR(ctx context.Context, client client.Client) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KnativeEventingNamespacedName,
 			Namespace: KnativeEventingNamespacedName,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: Knative.KnativeEventingSpec{},
 	}
@@ -208,7 +205,7 @@ func HandleKnativeServingCR(ctx context.Context, client client.Client) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KnativeServingNamespacedName,
 			Namespace: KnativeServingNamespacedName,
-			Labels:    kube.AddLabel(),
+			Labels:    kube.GetOrchestratorLabel(),
 		},
 		Spec: Knative.KnativeServingSpec{},
 	}

--- a/internal/controller/knative/knative_test.go
+++ b/internal/controller/knative/knative_test.go
@@ -1,0 +1,372 @@
+package knative
+
+import (
+	"context"
+	"testing"
+
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	olmclientsetfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/kube"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrros "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	Knative "knative.dev/operator/pkg/apis/operator/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testEventingName          = "test-name"
+	testServingName           = "test-name"
+	testChannel               = "test-channel"
+	orchestratorNamespace     = "orchestrator-namespace"
+	orchestratorOperatorGroup = "orchestrator-operator-group"
+	subscriptionName          = "orchestrator-subscription"
+)
+
+var objects []client.Object
+
+func TestHandleKNativeOperatorInstallation(t *testing.T) {
+	ctx := context.TODO()
+	// Create a fake client scheme
+	scheme := runtime.NewScheme()
+	utilruntime.Must(Knative.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+	utilruntime.Must(operatorsv1.AddToScheme(scheme))
+
+	testCases := []struct {
+		name                 string
+		subExists            bool
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "Subscription exists",
+			subExists:            true,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "Subscription does not exist",
+			subExists:            false,
+			expectedErrorMessage: "subscriptions.operators.coreos.com \"serverless-operator\" not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			desiredSubscription := kube.CreateSubscriptionObject(
+				KnativeSubscriptionName,
+				KnativeOperatorNamespace,
+				testChannel,
+				KnativeSubscriptionStartingCSV)
+
+			desiredSubscription.Status = v1alpha1.SubscriptionStatus{
+				InstallPlanRef: &corev1.ObjectReference{Name: "test-plan"},
+				CurrentCSV:     "test-csv",
+			}
+
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.subExists {
+				builder.WithObjects(desiredSubscription)
+
+			}
+			fakeClient := builder.Build()
+			fakeOLMClientSet := olmclientsetfake.NewSimpleClientset()
+			err := kube.InstallSubscriptionAndOperatorGroup(
+				ctx, fakeClient,
+				fakeOLMClientSet,
+				orchestratorOperatorGroup,
+				desiredSubscription)
+			assert.Equal(t, nil, err)
+
+			err = HandleKNativeOperatorInstallation(ctx, fakeClient, fakeOLMClientSet)
+			if tc.subExists {
+				assert.NoError(t, err)
+			} else {
+				assert.Equal(t, err.Error(), tc.expectedErrorMessage)
+			}
+
+			namespace := desiredSubscription.Namespace
+			subscriptionName := desiredSubscription.Name
+
+			subscription, err := fakeOLMClientSet.OperatorsV1alpha1().Subscriptions(namespace).Get(ctx, subscriptionName, metav1.GetOptions{})
+			if tc.subExists {
+				if subscription != nil {
+					assert.Equal(t, subscription.Spec.Channel, desiredSubscription.Spec.Channel)
+				}
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestHandleKnativeCR(t *testing.T) {
+	ctx := context.TODO()
+	// Create a fake client scheme
+	scheme := runtime.NewScheme()
+	utilruntime.Must(Knative.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+
+	testCases := []struct {
+		name                 string
+		eventingCRDExists    bool
+		servingCRDExists     bool
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "Both CRD exists",
+			eventingCRDExists:    true,
+			servingCRDExists:     true,
+			expectedErrorMessage: "",
+		},
+		{
+			name:                 "Only eventing exists",
+			eventingCRDExists:    true,
+			servingCRDExists:     false,
+			expectedErrorMessage: "customresourcedefinitions.apiextensions.k8s.io \"knativeservings.operator.knative.dev\" not found",
+		},
+		{
+			name:                 "Only serving CRD exists",
+			eventingCRDExists:    false,
+			servingCRDExists:     true,
+			expectedErrorMessage: "customresourcedefinitions.apiextensions.k8s.io \"knativeeventings.operator.knative.dev\" not found",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			eventingCRD := &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: KnativeEventingCRDName,
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{},
+			}
+			servingCRD := &apiextensionsv1.CustomResourceDefinition{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: KnativeServingCRDName,
+				},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{},
+			}
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.eventingCRDExists {
+				builder.WithObjects(eventingCRD)
+			}
+			if tc.servingCRDExists {
+				builder.WithObjects(servingCRD)
+			}
+			fakeClient := builder.Build()
+
+			err := HandleKnativeCR(ctx, fakeClient)
+			if err != nil {
+				assert.Equal(t, tc.expectedErrorMessage, err.Error())
+			}
+
+		})
+	}
+}
+
+func TestHandleKnativeEventingCR(t *testing.T) {
+	ctx := context.TODO()
+	// Create a fake client scheme
+	scheme := runtime.NewScheme()
+	utilruntime.Must(Knative.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+
+	testCases := []struct {
+		name           string
+		eventingExists bool
+		expectedError  error
+		eventingObject *Knative.KnativeEventing
+	}{
+		{
+			name:           "Update existing Knative Eventing",
+			eventingExists: true,
+			expectedError:  nil,
+			eventingObject: &Knative.KnativeEventing{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: KnativeAPIVersion,
+					Kind:       KnativeEventingKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testEventingName, // This is the field that indicates that an update has been performed
+					Namespace: KnativeEventingNamespacedName,
+				},
+				Spec: Knative.KnativeEventingSpec{},
+			},
+		},
+		{
+			name:           "Create Knative Eventing",
+			eventingExists: false,
+			expectedError:  nil,
+			eventingObject: &Knative.KnativeEventing{},
+		},
+	}
+
+	for _, tc := range testCases {
+		existingEventing := &Knative.KnativeEventing{}
+
+		if !tc.eventingExists {
+			t.Run(tc.name, func(t *testing.T) {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+				err := HandleKnativeEventingCR(ctx, fakeClient)
+				assert.Equal(t, tc.expectedError, err)
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: KnativeEventingNamespacedName, Namespace: KnativeEventingNamespacedName}, existingEventing)
+				assert.NoError(t, err)
+			})
+
+		} else {
+
+			t.Run(tc.name, func(t *testing.T) {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.eventingObject).Build()
+
+				err := HandleKnativeEventingCR(ctx, fakeClient)
+				assert.Equal(t, tc.expectedError, err)
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: testEventingName, Namespace: KnativeEventingNamespacedName}, existingEventing)
+				assert.NoError(t, err)
+				assert.Equal(t, existingEventing, tc.eventingObject)
+			})
+		}
+	}
+}
+
+func TestHandleKnativeServingCR(t *testing.T) {
+	ctx := context.TODO()
+	// Create a fake client scheme
+	scheme := runtime.NewScheme()
+	utilruntime.Must(Knative.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+
+	testCases := []struct {
+		name          string
+		servingExists bool
+		expectedError error
+		servingObject *Knative.KnativeServing
+	}{
+		{
+			name:          "Update existing Serving Eventing",
+			servingExists: true,
+			expectedError: nil,
+			servingObject: &Knative.KnativeServing{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: KnativeAPIVersion,
+					Kind:       KnativeServingKind,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testServingName, // This is the field that indicates that an update has been performed
+					Namespace: KnativeServingNamespacedName,
+				},
+				Spec: Knative.KnativeServingSpec{},
+			},
+		},
+		{
+			name:          "Create Knative Serving",
+			servingExists: false,
+			expectedError: nil,
+			servingObject: &Knative.KnativeServing{},
+		},
+	}
+
+	for _, tc := range testCases {
+		existingServing := &Knative.KnativeServing{}
+
+		if !tc.servingExists {
+			t.Run(tc.name, func(t *testing.T) {
+
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+				err := HandleKnativeServingCR(ctx, fakeClient)
+				assert.Equal(t, tc.expectedError, err)
+
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: KnativeServingNamespacedName, Namespace: KnativeServingNamespacedName}, existingServing)
+				assert.NoError(t, err)
+			})
+
+		} else {
+			t.Run(tc.name, func(t *testing.T) {
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.servingObject).Build()
+				err := HandleKnativeServingCR(ctx, fakeClient)
+				assert.Equal(t, tc.expectedError, err)
+
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: testServingName, Namespace: KnativeServingNamespacedName}, existingServing)
+				assert.NoError(t, err)
+				assert.Equal(t, existingServing, tc.servingObject)
+			})
+		}
+	}
+
+}
+
+func TestHandleKnativeCleanUp(t *testing.T) {
+	ctx := context.TODO()
+	// Create a fake client scheme
+	scheme := runtime.NewScheme()
+	utilruntime.Must(Knative.AddToScheme(scheme))
+	utilruntime.Must(corev1.AddToScheme(scheme))
+	utilruntime.Must(metav1.AddMetaToScheme(scheme))
+
+	testCases := []struct {
+		name       string
+		namespaces []*corev1.Namespace
+	}{
+		{
+			name: "Validate namespaces were deleted",
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      KnativeEventingNamespacedName,
+						Namespace: KnativeEventingNamespacedName,
+					},
+					Spec: corev1.NamespaceSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      KnativeOperatorNamespace,
+						Namespace: KnativeOperatorNamespace,
+					},
+					Spec: corev1.NamespaceSpec{},
+				}, {
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      KnativeServingNamespacedName,
+						Namespace: KnativeServingNamespacedName,
+					},
+					Spec: corev1.NamespaceSpec{},
+				},
+			},
+		},
+	}
+	tc := testCases[0]
+	t.Run(tc.name, func(t *testing.T) {
+		for _, ns := range tc.namespaces {
+			objects = append(objects, ns)
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+		for _, ns := range tc.namespaces {
+			namespace := &corev1.Namespace{}
+			err := fakeClient.Get(ctx, types.NamespacedName{Name: ns.Name}, namespace)
+			assert.True(t, apierrros.IsNotFound(err))
+		}
+
+		err := HandleKnativeCleanUp(ctx, fakeClient)
+		assert.NoError(t, err)
+
+		for _, ns := range tc.namespaces {
+			namespace := &corev1.Namespace{}
+			err = fakeClient.Get(ctx, types.NamespacedName{Name: ns.Name}, namespace)
+			assert.True(t, apierrros.IsNotFound(err))
+		}
+	})
+}

--- a/internal/controller/network_policy.go
+++ b/internal/controller/network_policy.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	kubeoperations "github.com/rhdhorchestrator/orchestrator-operator/internal/controller/kube"
+	knative "github.com/rhdhorchestrator/orchestrator-operator/internal/controller/knative"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrros "k8s.io/apimachinery/pkg/api/errors"
@@ -114,7 +115,7 @@ func createIngressRHDHSonataflowWorkflows(networkAndServerlessWorkflowNamespace,
 					// Allows traffic from pods in the K-Native Eventing namespace
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							metaDataNameLabel: knativeEventingNamespacedName,
+							metaDataNameLabel: knative.KnativeEventingNamespacedName,
 						},
 					},
 				},
@@ -122,7 +123,7 @@ func createIngressRHDHSonataflowWorkflows(networkAndServerlessWorkflowNamespace,
 					// Allows traffic from pods in the K-Native Serving namespace
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							metaDataNameLabel: knativeServingNamespacedName,
+							metaDataNameLabel: knative.KnativeServingNamespacedName,
 						},
 					},
 				},

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/kube"
 	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/rhdh"
+	knative "github.com/rhdhorchestrator/orchestrator-operator/internal/controller/knative"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
@@ -307,20 +308,20 @@ func (r *OrchestratorReconciler) reconcileKnative(ctx context.Context, serverles
 	// if subscription is disabled; check if subscription exists and handle delete
 	if !serverlessOperator.InstallOperator {
 		// handle cleanup
-		if err := handleKnativeCleanUp(ctx, r.Client); err != nil {
+		if err := knative.HandleKnativeCleanUp(ctx, r.Client); err != nil {
 			return err
 		}
 		return nil
 	}
 
 	// Subscription is enabled;
-	if err := handleKNativeOperatorInstallation(ctx, r.Client, r.OLMClient); err != nil {
+	if err := knative.HandleKNativeOperatorInstallation(ctx, r.Client, r.OLMClient); err != nil {
 		knativeLogger.Error(err, "Error occurred when installing Knative Operator resources")
 		return err
 	}
 
 	// handle knative CRs
-	if err := handleKnativeCR(ctx, r.Client); err != nil {
+	if err := knative.HandleKnativeCR(ctx, r.Client); err != nil {
 		knativeLogger.Error(err, "Error occurred when handling Knative Custom Resources")
 		return err
 	}
@@ -410,7 +411,7 @@ func (r *OrchestratorReconciler) addFinalizers(ctx context.Context, orchestrator
 
 func (r *OrchestratorReconciler) handleCleanUp(ctx context.Context, orchestrator *orchestratorv1alpha2.Orchestrator) error {
 	// cleanup Knative
-	if err := handleKnativeCleanUp(ctx, r.Client); err != nil {
+	if err := knative.HandleKnativeCleanUp(ctx, r.Client); err != nil {
 		return err
 	}
 	// cleanup Serverless Logic
@@ -503,8 +504,8 @@ func (r *OrchestratorReconciler) reconcileSubscription(ctx context.Context, obje
 				return nil
 			}
 		}
-		if (subscriptionObject.Namespace == knativeOperatorNamespace) && (subscriptionObject.Name == knativeSubscriptionName) {
-			err := handleKNativeOperatorInstallation(ctx, r.Client, r.OLMClient)
+		if (subscriptionObject.Namespace == knative.KnativeOperatorNamespace) && (subscriptionObject.Name == knative.KnativeSubscriptionName) {
+			err := knative.HandleKNativeOperatorInstallation(ctx, r.Client, r.OLMClient)
 			if err != nil && !apierrors.IsNotFound(err) {
 				logger.Error(err, "Error occurred when reconciling Serverless(K-Native) Operator's Subscription resource")
 				return nil


### PR DESCRIPTION
This PR will add Knative Unit tests, will move Knative resource to their own package, will expose some Knative consts to be public, and will fix small issues in the Knative code.

## Summary by Sourcery

Refactor Knative-related code by moving Knative resources to a dedicated package and adding comprehensive unit tests

New Features:
- Added comprehensive unit tests for Knative-related functionality

Enhancements:
- Moved Knative-related functions to a separate package for better code organization
- Exposed Knative constants to improve code readability and maintainability

Tests:
- Created unit tests for Knative operator installation
- Added tests for Knative Custom Resource handling
- Implemented tests for Knative cleanup operations