### PR TITLE
Remove Timestamp in version tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-TIMESTAMP ?= $(shell date +%Y-%m-%d)
-VERSION ?= 1.5.0-$(TIMESTAMP)
+VERSION ?= 1.5.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-03T08:34:09Z"
+    createdAt: "2025-04-08T02:36:39Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.5.0-2025-04-03
+  name: orchestrator-operator.v1.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -325,7 +325,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-2025-04-03
+                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -413,4 +413,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.5.0-2025-04-03
+  version: 1.5.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.5.0-2025-04-03
+  newTag: 1.5.0


### PR DESCRIPTION
Removing timestamp from version tag which was added to indicate mini releases. Now the operator is stable, we are switching to RC releases.

## Summary by Sourcery

Chores:
- Remove dynamic timestamp generation from version tag in Makefile