### PR TITLE
changes relevant for 1.5.0-rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.5.0
+VERSION ?= 1.5.0-rc1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,12 +239,12 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
-// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
+// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz
+// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-08T02:36:39Z"
+    createdAt: "2025-04-08T08:57:13Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.5.0
+  name: orchestrator-operator.v1.5.0-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -325,7 +325,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0
+                image: quay.io/orchestrator/orchestrator-go-operator:1.5.0-rc1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -413,4 +413,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.5.0
+  version: 1.5.0-rc1

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-08T08:57:13Z"
+    createdAt: "2025-04-08T09:22:13Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz'
-    orchestrator-integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz'
-    orchestrator-scaffolder-backend-integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz'
+    orchestrator-backend-dynamic-integrity: sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz'
+    orchestrator-integrity: sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz'
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -4,12 +4,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz'
-    orchestrator-integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.2.tgz'
-    orchestrator-scaffolder-backend-integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz'
+    orchestrator-backend-dynamic-integrity: sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz'
+    orchestrator-integrity: sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz'
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.5.0
+  newTag: 1.5.0-rc1

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -12,16 +12,16 @@ const ScaffolderBackendOrchestrator string = "scaffolderBackendOrchestrator"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.5.0-rc.2.tgz",
-			Integrity: "sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==",
+			Package:   "backstage-plugin-orchestrator-1.5.0-rc.3.tgz",
+			Integrity: "sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.2.tgz",
-			Integrity: "sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz",
+			Integrity: "sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==",
 		},
 		ScaffolderBackendOrchestrator: {
-			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.2.tgz",
-			Integrity: "sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==",
+			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz",
+			Integrity: "sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==",
 		},
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Prepare release candidate 1.5.0-rc1 by updating version references and package integrity checksums across various configuration files

New Features:
- Prepare release candidate for version 1.5.0-rc1

Chores:
- Update version references from 1.5.0 to 1.5.0-rc1 in Makefile, CSV, and kustomization files
- Update package integrity checksums for orchestrator plugins