### PR TITLE
Update plugins to version 1.5.1

### DIFF
--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,12 +239,12 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
-// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz
-// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
+// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.1.tgz
+// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-08T14:26:21Z"
+    createdAt: "2025-04-10T21:17:06Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -3,12 +3,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz'
-    orchestrator-integrity: sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz'
-    orchestrator-scaffolder-backend-integrity: sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz'
+    orchestrator-backend-dynamic-integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz'
+    orchestrator-integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.1.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz'
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -4,12 +4,12 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz'
-    orchestrator-integrity: sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz'
-    orchestrator-scaffolder-backend-integrity: sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz'
+    orchestrator-backend-dynamic-integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz'
+    orchestrator-integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.1.tgz'
+    orchestrator-scaffolder-backend-integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz'
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -105,15 +105,15 @@ To incorporate the Orchestrator plugins, append the following configuration to t
   ```
 ```yaml
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz"
-        integrity: sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz"
+        integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service.sonataflow-infra
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz"
-        integrity: sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==
+        package: "@redhat/backstage-plugin-orchestrator-1.5.1.tgz"
+        integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
         pluginConfig:
           dynamicPlugins:
             frontend:
@@ -130,8 +130,8 @@ To incorporate the Orchestrator plugins, append the following configuration to t
                     module: OrchestratorPlugin
                     path: /orchestrator
       - disabled: false
-        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz"
-        integrity: sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==  
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz"
+        integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==  
         pluginConfig:
           orchestrator:
             dataIndexService:
@@ -295,12 +295,12 @@ oc get crd orchestrators.rhdh.redhat.com -o json | jq '.metadata.annotations | w
 In the example output below, `orchestrator-backend-dynamic-integrity` is the integrity value and `orchestrator-backend-dynamic-package` is the package name:
 ```json
 {
-  "orchestrator-backend-dynamic-integrity": "sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==",
-  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz",
-  "orchestrator-integrity": "sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==",
-  "orchestrator-package": "@redhat/backstage-plugin-orchestrator-1.5.0-rc.3.tgz",
-  "orchestrator-scaffolder-backend-integrity": "sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==",
-  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz"
+  "orchestrator-backend-dynamic-integrity": "sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==",
+  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz",
+  "orchestrator-integrity": "sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==",
+  "orchestrator-package": "@redhat/backstage-plugin-orchestrator-1.5.1.tgz",
+  "orchestrator-scaffolder-backend-integrity": "sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==",
+  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz"
 }
 ```
 > Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0`)

--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -6,6 +6,6 @@ const (
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.stage.registry.redhat.com"
-	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.0-rc.3"
+	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.5.1"
 	CatalogBranch                  = "v1.5.x"
 )

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -12,16 +12,16 @@ const ScaffolderBackendOrchestrator string = "scaffolderBackendOrchestrator"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.5.0-rc.3.tgz",
-			Integrity: "sha512-SkvEkftCmeta/0hBbWFkLAgfkJenL/xn23kpHS4cXlkSaXN6Cn7V/tsLIoYiDuBghQ3jbivNiU0EcNgBkCIK2w==",
+			Package:   "backstage-plugin-orchestrator-1.5.1.tgz",
+			Integrity: "sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.0-rc.3.tgz",
-			Integrity: "sha512-TTUyOStMrjipF3i7Bzyz4GxAW+g6KBA8x5rlFE2jJjh4gtI8K1w2zNOGRfq0dniSxkZOYdhO15SX6CenFf4UrA==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.1.tgz",
+			Integrity: "sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==",
 		},
 		ScaffolderBackendOrchestrator: {
-			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.0-rc.3.tgz",
-			Integrity: "sha512-C+iazAp/i+x/iCtlA/l2Vc/AVO4TMfDxwn0hrXVEVbO9FHdaKt63EdLQ2dvtWslEnlhv/9eDAGp0L8Ct6lbRZA==",
+			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1.tgz",
+			Integrity: "sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==",
 		},
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Update Orchestrator plugins to version 1.5.1, including package versions, integrity checksums, and related configuration files

New Features:
- Upgrade Orchestrator plugins to version 1.5.1

Chores:
- Update plugin package references across multiple configuration and manifest files
- Update release scope and catalog branch