### PR TITLE
removing hyphen and adding @ for plugins

### DIFF
--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,11 +239,11 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1
 // +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
-// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator-1.5.1
+// +kubebuilder:metadata:annotations=orchestrator-package=@redhat/backstage-plugin-orchestrator@1.5.1
 // +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1
 // +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-14T15:21:46Z"
+    createdAt: "2025-04-14T16:50:08Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -4,11 +4,11 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     orchestrator-backend-dynamic-integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1'
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1'
     orchestrator-integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.1'
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator@1.5.1'
     orchestrator-scaffolder-backend-integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1'
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1'
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -5,11 +5,11 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
     orchestrator-backend-dynamic-integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
-    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1'
+    orchestrator-backend-dynamic-package: '@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1'
     orchestrator-integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
-    orchestrator-package: '@redhat/backstage-plugin-orchestrator-1.5.1'
+    orchestrator-package: '@redhat/backstage-plugin-orchestrator@1.5.1'
     orchestrator-scaffolder-backend-integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==
-    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1'
+    orchestrator-scaffolder-backend-package: '@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1'
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -105,14 +105,14 @@ To incorporate the Orchestrator plugins, append the following configuration to t
   ```
 ```yaml
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1"
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
         integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
         pluginConfig:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service.sonataflow-infra
       - disabled: false
-        package: "@redhat/backstage-plugin-orchestrator-1.5.1"
+        package: "@redhat/backstage-plugin-orchestrator@1.5.1"
         integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
         pluginConfig:
           dynamicPlugins:
@@ -130,7 +130,7 @@ To incorporate the Orchestrator plugins, append the following configuration to t
                     module: OrchestratorPlugin
                     path: /orchestrator
       - disabled: false
-        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1"
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
         integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==  
         pluginConfig:
           orchestrator:
@@ -296,11 +296,11 @@ In the example output below, `orchestrator-backend-dynamic-integrity` is the int
 ```json
 {
   "orchestrator-backend-dynamic-integrity": "sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==",
-  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic-1.5.1",
+  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1",
   "orchestrator-integrity": "sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==",
-  "orchestrator-package": "@redhat/backstage-plugin-orchestrator-1.5.1",
+  "orchestrator-package": "@redhat/backstage-plugin-orchestrator@1.5.1",
   "orchestrator-scaffolder-backend-integrity": "sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==",
-  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1"
+  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
 }
 ```
 > Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0`)

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -12,15 +12,15 @@ const ScaffolderBackendOrchestrator string = "scaffolderBackendOrchestrator"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.5.1",
+			Package:   "backstage-plugin-orchestrator@1.5.1",
 			Integrity: "sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.5.1",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic@1.5.1",
 			Integrity: "sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==",
 		},
 		ScaffolderBackendOrchestrator: {
-			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.5.1",
+			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1",
 			Integrity: "sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==",
 		},
 	}


### PR DESCRIPTION
## Summary by Sourcery

Update plugin package references by replacing hyphens with @ for version specification in various configuration and manifest files

Enhancements:
- Standardize plugin package version notation across multiple configuration files and Go code

Chores:
- Update package references in documentation, Kubernetes manifests, and internal controller configurations