### PR TITLE
Add Release 1.5 Doc

### DIFF
--- a/docs/main/README.md
+++ b/docs/main/README.md
@@ -55,7 +55,7 @@ chips is not supported.
 
 If you plan to deploy in a GitOps environment, make sure you have installed the `ArgoCD/Red Hat OpenShift GitOps` and
 the `Tekton/Red Hat Openshift Pipelines Install` operators following
-these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/gitops/README.md).
+these [instructions](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md).
 The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These
 templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and
 generate workflow K8s custom resources. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow
@@ -64,7 +64,7 @@ repository and to automatically trigger the Tekton pipelines as needed.
 - `ArgoCD/OpenShift GitOps` operator
     - Ensure at least one instance of `ArgoCD` exists in the designated namespace (referenced by `ARGOCD_NAMESPACE`
       environment variable).
-      Example [here](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/main/docs/gitops/resources/argocd-example.yaml)
+      Example [here](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/docs/gitops/resources/argocd-example.yaml)
     - Validated API is `argoproj.io/v1alpha1/AppProject`
 - `Tekton/OpenShift Pipelines` operator
     - Validated APIs are `tekton.dev/v1beta1/Task` and `tekton.dev/v1/Pipeline`
@@ -122,7 +122,7 @@ repository and to automatically trigger the Tekton pipelines as needed.
 ### Manual Installation
 
 1. Deploy the PostgreSQL reference implementation for persistence support in SonataFlow following
-   these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/postgresql/README.md)
+   these [instructions](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/postgresql/README.md)
 
 1. Create a namespace for the Orchestrator solution:
 
@@ -279,7 +279,7 @@ here: https://knative.dev/docs/eventing/brokers/broker-types/
 Alternatively, an in-memory broker could also be used, however it is not recommended to use it for production purposes.
 
 Follow
-these [instructions](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/refs/heads/main/docs/main/eventing-communication/README.md)
+these [instructions](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/refs/heads/main/docs/main/eventing-communication/README.md)
 to setup the Knative broker communication.
 
 ## Additional information

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -1,5 +1,5 @@
 # Prerequisites
-- RHDH 1.6 instance deployed with IDP configured (github, gitlab, ...)
+- RHDH 1.5 instance deployed with IDP configured (GitHub, GitLab, ...)
 - For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.5.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
 - A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
 

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -6,8 +6,8 @@
 # Installation steps
 
 ## Install the Orchestrator Operator
-In 1.6, the Orchestrator infrastructure is installed using the Orchestrator Operator.
-1. Install the Orchestrator Operator 1.6 from OperatorHub.
+In 1.5, the Orchestrator infrastructure is installed using the Orchestrator Operator.
+1. Install the Orchestrator Operator 1.5 from OperatorHub.
 1. Create orchestrator resource (operand) instance - ensure `rhdh: installOperator: False` is set, e.g.
    > Note: `${TARGET_NAMESPACE}` should be set to the desired namespace
 

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -1,13 +1,13 @@
 # Prerequisites
-- RHDH 1.5 instance deployed with IDP configured (github, gitlab, ...)
+- RHDH 1.6 instance deployed with IDP configured (github, gitlab, ...)
 - For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.5.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
 - A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
 
 # Installation steps
 
 ## Install the Orchestrator Operator
-In 1.5, the Orchestrator infrastructure is installed using the Orchestrator Operator.
-1. Install the Orchestrator Operator 1.5 from OperatorHub.
+In 1.6, the Orchestrator infrastructure is installed using the Orchestrator Operator.
+1. Install the Orchestrator Operator 1.6 from OperatorHub.
 1. Create orchestrator resource (operand) instance - ensure `rhdh: installOperator: False` is set, e.g.
    > Note: `${TARGET_NAMESPACE}` should be set to the desired namespace
 

--- a/docs/release-1.5/README.md
+++ b/docs/release-1.5/README.md
@@ -55,7 +55,7 @@ chips is not supported.
 
 If you plan to deploy in a GitOps environment, make sure you have installed the `ArgoCD/Red Hat OpenShift GitOps` and
 the `Tekton/Red Hat Openshift Pipelines Install` operators following
-these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/gitops/README.md).
+these [instructions](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md).
 The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These
 templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and
 generate workflow K8s custom resources. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow
@@ -64,14 +64,14 @@ repository and to automatically trigger the Tekton pipelines as needed.
 - `ArgoCD/OpenShift GitOps` operator
     - Ensure at least one instance of `ArgoCD` exists in the designated namespace (referenced by `ARGOCD_NAMESPACE`
       environment variable).
-      Example [here](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/main/docs/gitops/resources/argocd-example.yaml)
+      Example [here](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/docs/gitops/resources/argocd-example.yaml)
     - Validated API is `argoproj.io/v1alpha1/AppProject`
 - `Tekton/OpenShift Pipelines` operator
     - Validated APIs are `tekton.dev/v1beta1/Task` and `tekton.dev/v1/Pipeline`
     - Requires ArgoCD installed since the manifests are deployed in the same namespace as the ArgoCD instance.
 
   Remember to
-  enable [argocd](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml#L51)
+  enable [argocd](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/release-1.5/config/samples/_v1alpha3_orchestrator.yaml#L51)
   in your CR instance.
 
 ## Detailed Installation Guide
@@ -86,7 +86,7 @@ repository and to automatically trigger the Tekton pipelines as needed.
       ensure that the default settings in
       the [PostgreSQL values](https://github.com/rhdhorchestrator/orchestrator-helm-chart/blob/main/postgresql/values.yaml)
       file match the `postgres` field provided in
-      the [Orchestrator CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml#L23)
+      the [Orchestrator CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/release-1.5/config/samples/_v1alpha3_orchestrator.yaml#L23)
       file.
 1. Install Orchestrator operator
     1. Go to OperatorHub in your OpenShift Console.
@@ -122,7 +122,7 @@ repository and to automatically trigger the Tekton pipelines as needed.
 ### Manual Installation
 
 1. Deploy the PostgreSQL reference implementation for persistence support in SonataFlow following
-   these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/postgresql/README.md)
+   these [instructions](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/release-1.5/docs/postgresql/README.md)
 
 1. Create a namespace for the Orchestrator solution:
 
@@ -153,7 +153,7 @@ repository and to automatically trigger the Tekton pipelines as needed.
 1. Run the following commands to determine when the installation is completed:
 
    ```console
-   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/hack/wait_for_operator_installed.sh -O /tmp/wait_for_operator_installed.sh && chmod u+x /tmp/wait_for_operator_installed.sh && /tmp/wait_for_operator_installed.sh
+   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/release-1.5/hack/wait_for_operator_installed.sh -O /tmp/wait_for_operator_installed.sh && chmod u+x /tmp/wait_for_operator_installed.sh && /tmp/wait_for_operator_installed.sh
    ```
 
    During the installation process, the Orchestrator Operator creates and monitors the lifecycle of the sub-components
@@ -162,19 +162,18 @@ repository and to automatically trigger the Tekton pipelines as needed.
    Please refer to the [troubleshooting-section](#troubleshooting) for known issues with the operator resources.
 
 1. Apply the Orchestrator custom resource (CR) on the cluster to create an instance of RHDH and resources of
-   OpenShift
-   Serverless Operator and OpenShift Serverless Logic Operator.
+   OpenShift Serverless Operator and OpenShift Serverless Logic Operator.
    Make any changes to
-   the [CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml)
+   the [CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/release-1.5/config/samples/_v1alpha3_orchestrator.yaml)
    before applying it, or test the default Orchestrator CR:
     ```console
-    oc apply -n orchestrator -f https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/refs/heads/main/config/samples/_v1alpha3_orchestrator.yaml
+    oc apply -n orchestrator -f https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/refs/heads/release-1.5/config/samples/_v1alpha3_orchestrator.yaml
     ```
    Note: After the first reconciliation of the Orchestrator CR, changes to some of the fields in the CR may not be
    propagated/reconciled to the intended resource. For example, changing the `platform.resources.requests` field in
    the Orchestrator CR will not have any effect on the running instance of the SonataFlowPlatform (SFP) resource.
    For simplicity sake, that is the current design and may be revisited in the near future. Please refer to
-   the [CRD Parameter List](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/crd)
+   the [CRD Parameter List](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/release-1.5/docs/crd)
    to know which fields can be reconciled.
 
 ### Running The Setup Script
@@ -193,7 +192,7 @@ and labeling GitOps namespaces based on the cluster configuration.
    namespaces:
 
    ```console
-   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/hack/setup.sh -O /tmp/setup.sh && chmod u+x /tmp/setup.sh
+   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/release-1.5/hack/setup.sh -O /tmp/setup.sh && chmod u+x /tmp/setup.sh
    ```
 
 1. Run the script:
@@ -279,7 +278,7 @@ here: https://knative.dev/docs/eventing/brokers/broker-types/
 Alternatively, an in-memory broker could also be used, however it is not recommended to use it for production purposes.
 
 Follow
-these [instructions](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/refs/heads/main/docs/main/eventing-communication/README.md)
+these [instructions](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/refs/heads/release-1.5/docs/release-1.5/eventing-communication/README.md)
 to setup the Knative broker communication.
 
 ## Additional information

--- a/docs/release-1.5/README.md
+++ b/docs/release-1.5/README.md
@@ -1,0 +1,541 @@
+# Orchestrator Documentation
+
+For comprehensive documentation on the Orchestrator, please
+visit [https://www.rhdhorchestrator.io](https://www.rhdhorchestrator.io).
+
+## Installing the Orchestrator Go Operator
+
+Deploy the Orchestrator solution suite in an OCP cluster using the Orchestrator operator.\
+The operator installs the following components onto the target OpenShift cluster:
+
+- RHDH (Red Hat Developer Hub) Backstage
+- OpenShift Serverless Logic Operator (with Data-Index and Job Service)
+- OpenShift Serverless Operator
+    - Knative Eventing
+    - Knative Serving
+- (Optional) An ArgoCD project named `orchestrator`. Requires an pre-installed ArgoCD/OpenShift GitOps instance in the
+  cluster. Disabled by default
+- (Optional) Tekton tasks and build pipeline. Requires an pre-installed Tekton/OpenShift Pipelines instance in the
+  cluster. Disabled by default
+
+## Important Note for ARM64 Architecture Users
+
+Note that as of November 6, 2023, OpenShift Serverless Operator is based on RHEL 8 images which are not supported on the
+ARM64 architecture. Consequently, deployment of this operator on
+an [OpenShift Local](https://www.redhat.com/sysadmin/install-openshift-local) cluster on MacBook laptops with M1/M2
+chips is not supported.
+
+## Prerequisites
+
+- Logged in to a Red Hat OpenShift Container Platform (version 4.14 +) cluster as a cluster administrator.
+- [OpenShift CLI (oc)](https://docs.openshift.com/container-platform/4.13/cli_reference/openshift_cli/getting-started-cli.html)
+  is installed.
+- [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/docs/getting-started/) has been installed in your
+  cluster.
+- Your cluster has
+  a [default storage class](https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/persistent-storage-csi-sc-manage.html)
+  provisioned.
+- A GitHub API Token - to import items into the catalog, ensure you have a `GITHUB_TOKEN` with the necessary permissions
+  as detailed [here](https://backstage.io/docs/integrations/github/locations/).
+    - For classic token, include the following permissions:
+        - repo (all)
+        - admin:org (read:org)
+        - user (read:user, user:email)
+        - workflow (all) - required for using the software templates for creating workflows in GitHub
+    - For Fine grained token:
+        - Repository permissions: **Read** access to metadata, **Read** and **Write** access to actions, actions
+          variables, administration, code, codespaces, commit statuses, environments, issues, pull requests, repository
+          hooks, secrets, security events, and workflows.
+        - Organization permissions: **Read** access to members, **Read** and **Write** access to organization
+          administration, organization hooks, organization projects, and organization secrets.
+
+> <font color="red">⚠️**Warning**:</font> Skipping these steps will prevent the Orchestrator from functioning properly.
+
+### Deployment with GitOps
+
+If you plan to deploy in a GitOps environment, make sure you have installed the `ArgoCD/Red Hat OpenShift GitOps` and
+the `Tekton/Red Hat Openshift Pipelines Install` operators following
+these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/gitops/README.md).
+The Orchestrator installs RHDH and imports software templates designed for bootstrapping workflow development. These
+templates are crafted to ease the development lifecycle, including a Tekton pipeline to build workflow images and
+generate workflow K8s custom resources. Furthermore, ArgoCD is utilized to monitor any changes made to the workflow
+repository and to automatically trigger the Tekton pipelines as needed.
+
+- `ArgoCD/OpenShift GitOps` operator
+    - Ensure at least one instance of `ArgoCD` exists in the designated namespace (referenced by `ARGOCD_NAMESPACE`
+      environment variable).
+      Example [here](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/main/docs/gitops/resources/argocd-example.yaml)
+    - Validated API is `argoproj.io/v1alpha1/AppProject`
+- `Tekton/OpenShift Pipelines` operator
+    - Validated APIs are `tekton.dev/v1beta1/Task` and `tekton.dev/v1/Pipeline`
+    - Requires ArgoCD installed since the manifests are deployed in the same namespace as the ArgoCD instance.
+
+  Remember to
+  enable [argocd](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml#L51)
+  in your CR instance.
+
+## Detailed Installation Guide
+
+### From OperatorHub
+
+1. Deploying PostgreSQL reference implementation
+    - **If you do not have a PostgreSQL instance in your cluster** \
+      you can deploy the PostgreSQL reference implementation by following the
+      steps [here](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/postgresql/README.md).
+    - **If you already have PostgreSQL running in your cluster** \
+      ensure that the default settings in
+      the [PostgreSQL values](https://github.com/rhdhorchestrator/orchestrator-helm-chart/blob/main/postgresql/values.yaml)
+      file match the `postgres` field provided in
+      the [Orchestrator CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml#L23)
+      file.
+1. Install Orchestrator operator
+    1. Go to OperatorHub in your OpenShift Console.
+    1. Search for and install the Orchestrator Operator.
+1. Run the Setup Script
+    1. Follow the steps in the [Running the Setup Script](#running-the-setup-script) section to download and execute the
+       setup.sh script, which initializes the RHDH environment.
+1. Create an Orchestrator instance
+    1. Once the Orchestrator Operator is installed, navigate to Installed Operators.
+    1. Select Orchestrator Operator.
+    1. Click on Create Instance to deploy an Orchestrator instance.
+1. Verify resources and wait until they are running
+    1. From console run the following command get the necessary wait commands: \
+       `oc describe orchestrator orchestrator-sample -n openshift-operators | grep -A 10 "Run the following commands to wait until the services are ready:"`\
+
+       The command will return an output similar to the one below, which lists several oc wait commands. This depends on
+       your specific cluster.
+       ```bash
+         oc wait -n openshift-serverless deploy/knative-openshift --for=condition=Available --timeout=5m
+         oc wait -n knative-eventing knativeeventing/knative-eventing --for=condition=Ready --timeout=5m
+         oc wait -n knative-serving knativeserving/knative-serving --for=condition=Ready --timeout=5m
+         oc wait -n openshift-serverless-logic deploy/logic-operator-rhel8-controller-manager --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra sonataflowplatform/sonataflow-platform --for=condition=Succeed --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-data-index-service --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-jobs-service --for=condition=Available --timeout=5m
+         oc get networkpolicy -n sonataflow-infra
+         ```
+    1. Copy and execute each command from the output in your terminal. These commands ensure that all necessary services
+       and resources in your OpenShift environment are available and running correctly.
+    1. If any service does not become available, verify the logs for that service or
+       consult [troubleshooting steps](https://www.rhdhorchestrator.io/main/docs/serverless-workflows/troubleshooting/).
+
+### Manual Installation
+
+1. Deploy the PostgreSQL reference implementation for persistence support in SonataFlow following
+   these [instructions](https://github.com/rhdhorchestrator/orchestrator-helm-operator/blob/main/docs/postgresql/README.md)
+
+1. Create a namespace for the Orchestrator solution:
+
+   ```console
+   oc new-project orchestrator
+   ```
+
+1. Run the Setup Script
+    1. Follow the steps in the [Running the Setup Script](#running-the-setup-script) section to download and execute the
+       setup.sh script, which initializes the RHDH environment.
+
+1. Use the following manifest to install the operator in an OCP cluster:
+
+   ```yaml
+   apiVersion: operators.coreos.com/v1alpha1
+   kind: Subscription
+   metadata:
+     name: orchestrator-operator
+     namespace: openshift-operators
+   spec:
+     channel: stable
+     installPlanApproval: Automatic
+     name: orchestrator-operator
+     source: redhat-operators
+     sourceNamespace: openshift-marketplace
+   ```
+
+1. Run the following commands to determine when the installation is completed:
+
+   ```console
+   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/hack/wait_for_operator_installed.sh -O /tmp/wait_for_operator_installed.sh && chmod u+x /tmp/wait_for_operator_installed.sh && /tmp/wait_for_operator_installed.sh
+   ```
+
+   During the installation process, the Orchestrator Operator creates and monitors the lifecycle of the sub-components
+   operators: RHDH operator, OpenShift Serverless operator and OpenShift Serverless Logic operator. Furthermore, it
+   creates the necessary CRs and resources needed for orchestrator to function properly.
+   Please refer to the [troubleshooting-section](#troubleshooting) for known issues with the operator resources.
+
+1. Apply the Orchestrator custom resource (CR) on the cluster to create an instance of RHDH and resources of
+   OpenShift
+   Serverless Operator and OpenShift Serverless Logic Operator.
+   Make any changes to
+   the [CR](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/config/samples/_v1alpha3_orchestrator.yaml)
+   before applying it, or test the default Orchestrator CR:
+    ```console
+    oc apply -n orchestrator -f https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/refs/heads/main/config/samples/_v1alpha3_orchestrator.yaml
+    ```
+   Note: After the first reconciliation of the Orchestrator CR, changes to some of the fields in the CR may not be
+   propagated/reconciled to the intended resource. For example, changing the `platform.resources.requests` field in
+   the Orchestrator CR will not have any effect on the running instance of the SonataFlowPlatform (SFP) resource.
+   For simplicity sake, that is the current design and may be revisited in the near future. Please refer to
+   the [CRD Parameter List](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/crd)
+   to know which fields can be reconciled.
+
+### Running The Setup Script
+
+The setup.sh script simplifies the initialization of the RHDH environment by creating the required authentication secret
+and labeling GitOps namespaces based on the cluster configuration.
+
+1. Create a namespace for the RHDH instance. This namespace is predefined as the default in both the setup.sh script and
+   the Orchestrator CR but can be overridden if needed.
+
+   ```console
+   oc new-project rhdh
+   ```
+
+1. Download the setup script from the github repository and run it to create the RHDH secret and label the GitOps
+   namespaces:
+
+   ```console
+   wget https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-go-operator/main/hack/setup.sh -O /tmp/setup.sh && chmod u+x /tmp/setup.sh
+   ```
+
+1. Run the script:
+   ```console
+   /tmp/setup.sh --use-default
+   ```
+
+**NOTE:** If you don't want to use the default values, omit the `--use-default` and the script will prompt you for
+input.
+
+The contents will vary depending on the configuration in the cluster. The following list details all the keys that can
+appear in the secret:
+
+> - `BACKEND_SECRET`: Value is randomly generated at script execution. This is the only mandatory key required to be in
+    the secret for the RHDH Operator to start.
+> - `K8S_CLUSTER_URL`: The URL of the Kubernetes cluster is obtained dynamically using `oc whoami --show-server`.
+> - `K8S_CLUSTER_TOKEN`: The value is obtained dynamically based on the provided namespace and service account.
+> - `GITHUB_TOKEN`: This value is prompted from the user during script execution and is not predefined.
+> - `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`: The value for both these fields are used to authenticate against
+    GitHub. For more information open this [link](https://backstage.io/docs/auth/github/provider/).
+> - `GITLAB_HOST` and `GITLAB_TOKEN`: The value for both these fields are used to authenticate against
+    GitLab.
+> - `ARGOCD_URL`: This value is dynamically obtained based on the first ArgoCD instance available.
+> - `ARGOCD_USERNAME`: Default value is set to `admin`.
+> - `ARGOCD_PASSWORD`: This value is dynamically obtained based on the ArgoCD instance available.
+
+Keys will not be added to the secret if they have no values associated. So for instance, when deploying in a cluster
+without the GitOps operators, the `ARGOCD_URL`, `ARGOCD_USERNAME` and `ARGOCD_PASSWORD` keys will be omitted in the
+secret.
+
+Sample of a secret created in a GitOps environment:
+
+```console
+$> oc get secret -n rhdh -o yaml backstage-backend-auth-secret
+apiVersion: v1
+data:
+  ARGOCD_PASSWORD: ...
+  ARGOCD_URL: ...
+  ARGOCD_USERNAME: ...
+  BACKEND_SECRET: ...
+  GITHUB_TOKEN: ...
+  K8S_CLUSTER_TOKEN: ...
+  K8S_CLUSTER_URL: ...
+kind: Secret
+metadata:
+  creationTimestamp: "2024-05-07T22:22:59Z"
+  name: backstage-backend-auth-secret
+  namespace: rhdh-operator
+  resourceVersion: "4402773"
+  uid: 2042e741-346e-4f0e-9d15-1b5492bb9916
+type: Opaque
+```
+
+### Enabling Monitoring for Workflows
+
+If you want to enable monitoring for workflows, you shall enable it in the `Orchestrator` CR as follows:
+
+```yaml
+apiVersion: rhdh.redhat.com/v1alpha3
+kind: Orchestrator
+metadata:
+  name: ...
+spec:
+  ...
+  platform:
+    ...
+    monitoring:
+      enabled: true
+      ...
+```
+
+After the CR is deployed, follow
+the [instructions](https://sonataflow.org/serverlessworkflow/main/cloud/operator/monitoring-workflows.html) to deploy
+Prometheus, Grafana and the sample Grafana dashboard.
+
+### Using Knative eventing communication
+
+To enable eventing communication communication between the different components (Data Index, Job Service and
+Workflows), a broker should be used. Kafka is a good candidate as it fulfills the reliability need. You can find the
+list of available brokers for Knative is
+here: https://knative.dev/docs/eventing/brokers/broker-types/
+
+Alternatively, an in-memory broker could also be used, however it is not recommended to use it for production purposes.
+
+Follow
+these [instructions](https://raw.githubusercontent.com/rhdhorchestrator/orchestrator-helm-operator/refs/heads/main/docs/main/eventing-communication/README.md)
+to setup the Knative broker communication.
+
+## Additional information
+
+### Proxy configuration
+
+Your Backstage instance might be configured to work with a proxy. In that case you need to tell Backstage to bypass the
+workflow for requests to workflow namespaces and sonataflow namespace (`sonataflow-infra`). You need to add the
+namespaces to the environment variable `NO_PROXY`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,
+`.my-workflow-namespace`. Note the `.` before the namespace name.
+
+### Additional Workflow Namespaces
+
+When deploying a workflow in a namespace different from where Sonataflow services are running (e.g., sonataflow-infra),
+several essential steps must be followed:
+
+1. **Allow Traffic from the Workflow Namespace:**
+   To allow Sonataflow services to accept traffic from workflows, either create an additional network policy or update
+   the existing policy with the new workflow namespace.
+
+   ###### Create Additional Network Policy
+   ```console
+   oc create -f - <<EOF
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-external-workflows-to-sonataflow-infra
+     # Namespace where network policies are deployed
+     namespace: sonataflow-infra
+   spec:
+     podSelector: {}
+     ingress:
+       - from:
+         - namespaceSelector:
+             matchLabels:
+               # Allow Sonataflow services to communicate with new/additional workflow namespace.
+               kubernetes.io/metadata.name: <new-workflow-namespace>
+   EOF
+   ```
+   ###### Alternatively - Update Existing Network Policy
+    ```console
+   oc -n sonataflow-infra patch networkpolicy allow-rhdh-to-sonataflow-and-workflows --type='json' \
+   -p='[
+    {
+      "op": "add",
+      "path": "/spec/ingress/0/from/-",
+      "value": {
+        "namespaceSelector": {
+          "matchLabels": {
+            "kubernetes.io/metadata.name": <new-workflow-namespace>
+          }
+        }          
+      }
+    }]'
+
+2. **Identify the RHDH Namespace:**
+   Retrieve the namespace where RHDH is running by executing:
+   ```console
+   oc get backstage -A
+   ```
+   Store the namespace value in `$RHDH_NAMESPACE` in the Network Policy manifest below.
+
+3. **Identify the Sonataflow Services Namespace:**
+   Check the namespace where Sonataflow services are deployed:
+   ```console
+   oc get sonataflowclusterplatform -A
+   ```
+   If there is no cluster platform, check for a namespace-specific platform:
+   ```console
+   oc get sonataflowplatform -A
+   ```
+   Store the namespace value in `$WORKFLOW_NAMESPACE`.
+
+4. **Set Up a Network Policy:**
+   Configure a network policy to allow traffic only between RHDH, Knative, Sonataflow services, and workflows.
+   ```console
+   oc create -f - <<EOF
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-rhdh-to-sonataflow-and-workflows
+     namespace: $ADDITIONAL_NAMESPACE
+   spec:
+     podSelector: {}
+     ingress:
+       - from:
+         - namespaceSelector:
+             matchLabels:
+               # Allows traffic from pods in the RHDH namespace.
+               kubernetes.io/metadata.name: $RHDH_NAMESPACE
+         - namespaceSelector:
+             matchLabels:
+               # Allow traffic from pods in the in the Workflow namespace.
+               kubernetes.io/metadata.name: $WORKFLOW_NAMESPACE
+         - namespaceSelector:
+             matchLabels:
+               # Allows traffic from pods in the K-Native Eventing namespace.
+               kubernetes.io/metadata.name: knative-eventing
+         - namespaceSelector:
+             matchLabels:
+               # Allows traffic from pods in the K-Native Serving namespace.
+               kubernetes.io/metadata.name: knative-serving
+   EOF
+   ```
+   To allow unrestricted communication between all pods within the workflow's namespace, create the
+   `allow-intra-namespace` network policy.
+    ```console
+   oc create -f - <<EOF
+   apiVersion: networking.k8s.io/v1
+   kind: NetworkPolicy
+   metadata:
+     name: allow-intra-namespace
+     namespace:  $ADDITIONAL_NAMESPACE
+   spec:
+     # Apply this policy to all pods in the namespace
+     podSelector: {}
+     # Specify policy type as 'Ingress' to control incoming traffic rules
+     policyTypes:
+       - Ingress
+     ingress:
+       - from:
+           # Allow ingress from any pod within the same namespace
+           - podSelector: {}
+   EOF
+   ```
+
+5. **Ensure Persistence for the Workflow:**
+   If persistence is required, follow these steps:
+
+* **Create a PostgreSQL Secret:**
+  The workflow needs its own schema in PostgreSQL. Create a secret containing the PostgreSQL credentials in the
+  workflow's namespace:
+  ```
+  oc get secret sonataflow-psql-postgresql -n sonataflow-infra -o yaml > secret.yaml
+  sed -i '/namespace: sonataflow-infra/d' secret.yaml
+  oc apply -f secret.yaml -n $ADDITIONAL_NAMESPACE
+  ```
+* **Configure the Namespace Attribute:**
+  Add the namespace attribute under the `serviceRef` property where the PostgreSQL server is deployed.
+  ```yaml
+  apiVersion: sonataflow.org/v1alpha08
+  kind: SonataFlow
+    ...
+  spec:
+    ...
+    persistence:
+      postgresql:
+        secretRef:
+          name: sonataflow-psql-postgresql
+          passwordKey: postgres-password
+          userKey: postgres-username
+        serviceRef:
+          databaseName: sonataflow
+          databaseSchema: greeting
+          name: sonataflow-psql-postgresql
+          namespace: $POSTGRESQL_NAMESPACE
+          port: 5432
+  ```
+  Replace POSTGRESQL_NAMESPACE with the namespace where the PostgreSQL server is deployed.
+
+By following these steps, the workflow will have the necessary credentials to access PostgreSQL and will correctly
+reference the service in a different namespace.
+
+### GitOps environment
+
+See the
+dedicated [document](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
+
+### Deploying PostgreSQL reference implementation
+
+See [here](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/postgresql/README.md)
+
+### ArgoCD and workflow namespace
+
+If you manually created the workflow namespaces (e.g., `$WORKFLOW_NAMESPACE`), run this command to add the required
+label that allows ArgoCD to deploy instances there:
+
+```console
+oc label ns $WORKFLOW_NAMESPACE argocd.argoproj.io/managed-by=$ARGOCD_NAMESPACE
+```
+
+### Workflow installation
+
+Follow [Workflows Installation](https://www.rhdhorchestrator.io/serverless-workflows-config/)
+
+## Cleanup
+
+**\/!\\ Before removing the orchestrator, make sure you have first removed any installed workflows. Otherwise the
+deletion may become hung in a terminating state.**
+
+To remove the operator, first remove the operand resources
+
+Run:
+
+```console
+oc delete namespace orchestrator
+```
+
+to delete the Orchestrator CR. This will remove the OSL, Serverless and RHDH Operators, Sonataflow CRs.
+
+To clean up the rest of resources run
+
+```console
+oc delete namespace sonataflow-infra rhdh
+```
+
+If you want to remove *knative* related resources, you may also run:
+
+```console
+oc get crd -o name | grep -e knative | xargs oc delete
+```
+
+To remove the operator from the cluster, delete the subscription:
+
+```console
+oc delete subscriptions.operators.coreos.com orchestrator-operator -n openshift-operators
+```
+
+Note that the CRDs created during the installation process will remain in the cluster.
+
+**Compatibility Matrix between Orchestrator Operator and Dependencies**
+
+| Orchestrator Operator | RHDH  | OSL    | Serverless |
+|-----------------------|-------|--------|------------|
+| Orchestrator 1.5.0    | 1.5.1 | 1.35.0 | 1.35.0     |
+
+**Compatibility Matrix for Orchestrator Plugins**
+
+| Orchestrator Plugins  Version                                                                           | Orchestrator Operator  Version |
+|---------------------------------------------------------------------------------------------------------|--------------------------------|
+| Orchestrator Backend (backstage-plugin-orchestrator-backend-dynamic@1.5.1)                              | 1.5.0                          |
+| Orchestrator (backstage-plugin-orchestrator@1.5.1)                                                      | 1.5.0                          |
+| Orchestrator Scaffolder Backend (backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1) | 1.5.0                          |
+
+## Troubleshooting/Known Issue
+
+### Zip bomb detected with Orchestrator Plugin
+
+Currently, there is a known issue with RHDH pod starting up due to the size of the orchestrator plugin.
+The error `Zip bomb detected in backstage-plugin-orchestrator-1.5.0` will be seen and this can be resolved by
+increasing the `MAX_ENTRY_SIZE"` of the initContainer which downloads the plugins. This will be resolved in the next
+operator release.
+More information can be
+found [here](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.0/html/administration_guide_for_red_hat_developer_hub/rhdh-installing-dynamic-plugins#basic-configuration-of-dynamic-plugins).
+
+To fix this issue, please run patch command within the RHDH instance namespace:
+
+```console
+oc -n <rhdh-namespace> patch deployment <deployment-name> --type='json' -p='[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/initContainers/0/env/-",
+    "value": {
+      "name": "MAX_ENTRY_SIZE",
+      "value": "30000000"
+    }
+  }
+]'
+```

--- a/docs/release-1.5/eventing-communication/README.md
+++ b/docs/release-1.5/eventing-communication/README.md
@@ -1,0 +1,199 @@
+# Using Knative broker for eventing communication
+
+Knative Broker enables decoupled event-driven communication by routing events from producers to subscribers based on Triggers, simplifying event management in Kubernetes.
+
+Orchestrator supports two flows for enabling Knative eventing communication: 
+1. Enabling Eventing via Orchestrator CR
+2. Enabling Eventing Post Orchestrator CR Application
+
+## Enabling Eventing via Orchestrator CR
+
+This flow will include configuring the Orchestrator CR to use an existing Knative Broker. To do so, the following needs to be added to the Orchestrator CR:
+
+```yaml
+platform: 
+  eventing: 
+    broker: 
+      name: "my-knative" # Name of existing Broker instance.
+      namespace: "knative" # Namespace of existing Broker instance.
+```
+Please not that this can only be done during the first CR application, otherwise you would have to follow the Enabling Eventing Post Orchestrator CR Application flow. 
+
+## Enabling Eventing Post Orchestrator CR Application
+
+This flow will including having no Eventing Broker configured in the Orchestrator CR, rather patching the SonataflowPlatform post-installation with the Knative broker. 
+
+You can follow an automated or a manual approach:
+
+## Automated installation steps
+Usage:
+```
+Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] ./eventing-automate-install.sh
+  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR
+  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators
+  BROKER_NAME                         Name of the broker to install
+  BROKER_NAMESPACE                    Namespace in which the broker must be installed
+  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'
+  INSTALL_KAFKA_CLUSTER               Optional, if set to true, indicates that Kafka cluster must be installed. Will only be used if BROKER_TYPE is 'Kafka'. Default is: true
+  KAFKA_REPLICATION_FACTOR            Optional, only used if INSTALL_KAFKA_CLUSTER is set to false and BROKER_TYPE is 'Kafka', provide the replication factor for the Kafka cluster
+```
+### Using Kafka broker
+#### With pre-existing Kafka cluster
+```console
+ORCHESTRATOR_NAME=orchestrator-sample \
+BROKER_NAME=kafka-broker \
+BROKER_NAMESPACE=sonataflow-infra \
+INSTALL_KAFKA_CLUSTER=false \
+KAFKA_REPLICATION_FACTOR=1 ./eventing-automate-install.sh
+```
+#### Without existing Kafka cluster
+```console
+ORCHESTRATOR_NAME=orchestrator-sample \
+BROKER_NAME=kafka-broker \
+BROKER_NAMESPACE=sonataflow-infra \
+INSTALL_KAFKA_CLUSTER=true ./eventing-automate-install.sh
+```
+### Using in-memory-broker
+```console
+BROKER_TYPE=in-memory \
+ORCHESTRATOR_NAME=orchestrator-sample \
+BROKER_NAME=simple-broker \
+BROKER_NAMESPACE=sonataflow-infra ./eventing-automate-install.sh
+```
+
+## Manual installation steps
+
+### Using Kafka broker
+A Kafka broker will bring resiliency and reliability to event losses to the sontaflow eventing context.
+
+#### Pre-requisites
+
+1. A Kafka cluster running, see https://strimzi.io/quickstarts/ for a quickstart setup
+2. OpenShift version 4.15 and up, as older versions are not supported 
+
+#### Installation steps
+1. Configure and enable Kafka broker feature in Knative: https://knative.dev/v1.15-docs/eventing/brokers/broker-types/kafka-broker/
+```console
+oc apply --filename https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.15.8/eventing-kafka-controller.yaml
+oc apply --filename https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v1.15.8/eventing-kafka-broker.yaml
+```
+> [!NOTE]
+> At the time this document was written, the compatible `knative` version was `v1.15.8`. Please refer to [the official documentation](https://knative.dev/v1.15-docs/eventing/brokers/broker-types/kafka-broker/) for more up-to-date instructions for the Kafka broker setup. Knative 1.16.x cannot be used due to incompatibillity with k8s and OCP versions. For more information, please advise the release-compatibillity tables [here](https://github.com/knative/community/blob/main/mechanics/RELEASE-SCHEDULE.md#releases-supported-by-community) and [here](https://access.redhat.com/solutions/4870701).
+ * Review the `Security Context Constraints` (`scc`) to be granted to the `knative-kafka-broker-data-plane` service account used by the `kafka-broker-receiver`  deployment:
+```console
+oc get deployments.apps -n knative-eventing kafka-broker-receiver -oyaml | oc adm policy scc-subject-review --filename -
+```
+  * i.e:
+```console
+oc -n knative-eventing adm policy add-scc-to-user nonroot-v2 -z knative-kafka-broker-data-plane
+```
+* Make sure the `replication.factor` of your Kafka cluster matches the one of the `kafka-broker-config` ConfigMap. With the Strimzi quickstart example, this value is set to `1` (see ConfigMap `my-cluster-dual-role-0`):
+```console
+oc patch cm kafka-broker-config -n knative-eventing \
+   --type merge \
+   -p '
+   {
+     "data": {
+       "default.topic.replication.factor": "1"
+     }
+   }'
+```
+* Similarly, make sure `bootstrap.servers` property from previous `kafka-broker-config` ConfigMap points to the right bootstrap server, it should match the `Service` created for the Kafka cluster:
+```console
+oc -n kafka get svc
+```
+* Wait for the `kafka-broker-receiver` resource to be ready:
+```console
+oc wait --for condition=ready=true pod -l app=kafka-broker-receiver -n knative-eventing --timeout=60s
+```
+
+1. Create Kafka broker (Knative `sink`): see https://docs.openshift.com/serverless/1.35/eventing/brokers/kafka-broker.html for more details:
+```Console
+BROKER_NAME=kafka-broker # change the name to match your needs
+BROKER_NAMESPACE=sonataflow-infra # change to your target namespace
+echo "apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    # case-sensitive
+    eventing.knative.dev/broker.class: Kafka
+  name: ${BROKER_NAME}
+  namespace: ${BROKER_NAMESPACE}
+spec:
+  # Configuration specific to this broker.
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: ${BROKER_NAME}-config
+    namespace: knative-eventing" | oc apply -n sonataflow-infra -f -
+```
+
+### Using in-memory-broker
+You do not need any external resources to install an in-memory broker:
+```Console
+BROKER_NAME=kafka-broker # change the name to match your needs
+BROKER_NAMESPACE=sonataflow-infra # change to your target namespace
+echo "apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: ${BROKER_NAME}
+  namespace: ${BROKER_NAMESPACE} | oc apply -n sonataflow-infra -f -
+```
+
+> [!WARNING]
+> When using this type of broker you should keep in mind they are neither reliable nor resilient to event losses.
+### Common steps
+1. Configure the `sonataflowplatform` with your Broker's information. 
+
+```console
+oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type merge \
+   -p '
+{
+  "spec": {
+    "eventing": {
+      "broker": {
+        "ref": {
+          "apiVersion": "eventing.knative.dev/v1",
+          "kind": "Broker",
+          "name": "'"${BROKER_NAME}"'",
+          "namespace": "'"${BROKER_NAMESPACE}"'"
+          }            
+        }
+      }
+    }
+  }
+```
+Scale the Job service and data index service deployments:
+
+```console
+oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=0
+
+oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=0
+
+oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=1
+
+oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=1
+```
+
+The `sinkbinding` and `trigger` resources should be automatically created by the OpenShift Serverless Logic operator:
+```
+$ oc -n sonataflow-infra get sinkbindings.sources.knative.dev 
+NAME                                  SINK                                                                                        READY   REASON
+sonataflow-platform-jobs-service-sb   http://kafka-broker-ingress.knative-eventing.svc.cluster.local/orchestrator/kafka-broker    True    
+
+$ oc -n sonataflow-infra get trigger
+NAME                                                              BROKER         SUBSCRIBER_URI                                                                             READY   REASON
+data-index-jobs-2ac1baab-d856-40bc-bcec-c6dd50951419              kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/jobs          True    
+data-index-process-definition-634c6f230b6364cdda8272f98c5d58722   kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/definitions   True    
+data-index-process-error-2ac1baab-d856-40bc-bcec-c6dd50951419     kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/processes     True    
+data-index-process-node-2ac1baab-d856-40bc-bcec-c6dd50951419      kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/processes     True    
+data-index-process-sla-2ac1baab-d856-40bc-bcec-c6dd50951419       kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/processes     True    
+data-index-process-state-2ac1baab-d856-40bc-bcec-c6dd50951419     kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/processes     True    
+data-index-process-variable-6f721bf111e75efc394000bca9884ae22ac   kafka-broker   http://sonataflow-platform-data-index-service.orchestrator.svc.cluster.local/processes     True    
+jobs-service-create-job-2ac1baab-d856-40bc-bcec-c6dd50951419      kafka-broker   http://sonataflow-platform-jobs-service.orchestrator.svc.cluster.local/v2/jobs/events      True    
+jobs-service-delete-job-2ac1baab-d856-40bc-bcec-c6dd50951419      kafka-broker   http://sonataflow-platform-jobs-service.orchestrator.svc.cluster.local/v2/jobs/events      True    
+```
+
+For each workflow deployed:
+  * A `sinkbinding` resource will be created: it will inject the `K_SINK` environment variable into the  `deployment` resource. See https://knative.dev/docs/eventing/custom-event-source/sinkbinding/ for more information about`sinkbinding`.
+  * A `trigger` resource will be created for each event consumed by the workflow. See https://knative.dev/docs/eventing/triggers/ for more information about `trigger` and their usage.

--- a/docs/release-1.5/eventing-communication/eventing-automate-install.sh
+++ b/docs/release-1.5/eventing-communication/eventing-automate-install.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+set -e
+set -x
+program_name=$0
+
+KNATIVE_VERSION=1.15.8
+
+function usage {
+    echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
+    echo "  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR"
+    echo "  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators"
+    echo "  BROKER_NAME                         Name of the broker to install"
+    echo "  BROKER_NAMESPACE                    Namespace in which the broker must be installed"
+    echo "  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'"
+    echo "  INSTALL_KAFKA_CLUSTER               Optional, if set to true, indicates that Kafka cluster must be installed. Will only be used if BROKER_TYPE is 'Kafka'. Default is: true"
+    echo "  KAFKA_REPLICATION_FACTOR            Optional, only used if INSTALL_KAFKA_CLUSTER is set to false and BROKER_TYPE is 'Kafka', provide the replication factor for the Kafka cluster"
+    exit 1
+}
+
+OCP_VERSION=$(oc get clusterversion -o jsonpath='{.items[0].status.history[0].version}')
+if [[ -z "$OCP_VERSION" ]]; then
+    echo "Error: Could not retrieve OpenShift version."
+    usage
+fi
+
+if [[ "$OCP_VERSION" < "4.15" ]]; then
+    echo "Error: OpenShift version $OCP_VERSION must be 4.15 or higher."
+    usage
+fi
+
+if [[ -z "${ORCHESTRATOR_NAMESPACE}" ]]; then
+  ORCHESTRATOR_NAMESPACE=openshift-operators
+fi
+
+if [[ -z "${ORCHESTRATOR_NAME}" ]]; then
+  echo "ORCHESTRATOR_NAME env variable must be set to the name of the deployed orchestrator CR; e.g: orchestrator-sample"
+  usage
+fi
+
+if [[ -z "${BROKER_TYPE}" ]]; then
+  BROKER_TYPE=Kafka
+fi
+
+if [[ "$BROKER_TYPE" != "Kafka" && "$BROKER_TYPE" != "in-memory" ]]; then
+  echo 'Error: BROKER_TYPE env variable must be set to either "Kafka" or "in-memory"'
+  usage
+fi
+
+if [[ -z "${INSTALL_KAFKA_CLUSTER}" ]]; then
+  if [ "$BROKER_TYPE" == "Kafka" ]; then
+    INSTALL_KAFKA_CLUSTER=true
+  else
+    INSTALL_KAFKA_CLUSTER=false
+  fi
+fi
+
+if [[ -z "${BROKER_NAME}" ]]; then
+  echo "BROKER_NAME env variable must be set to the name of the broker; e.g: kafka-broker."
+  usage
+fi
+
+if [[ -z "${BROKER_NAMESPACE}" ]]; then
+  echo "BROKER_NAMESPACE env variable must be set to the namespace of the broker; e.g: ${TARGET_NS}."
+  usage
+fi
+
+if [ "$INSTALL_KAFKA_CLUSTER" == true ]; then
+    echo "Installing a kafka cluster using Strimzi default quickstart: https://strimzi.io/quickstarts/"
+    oc create namespace kafka
+    oc create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
+    oc apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n kafka 
+    oc wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka 
+    KAFKA_REPLICATION_FACTOR=1
+fi
+
+if [ "$BROKER_TYPE" == "Kafka" ]; then
+    if [[ -z "${KAFKA_REPLICATION_FACTOR}" ]]; then
+      echo "KAFKA_REPLICATION_FACTOR env variable must be set when INSTALL_KAFKA_CLUSTER is set to false and BROKER_TYPE is 'Kafka'."
+      usage
+    fi
+    echo "Installing Knative ${KNATIVE_VERSION} Kafka-related resources"
+
+    oc apply --filename https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v"${KNATIVE_VERSION}"/eventing-kafka-controller.yaml
+    oc apply --filename https://github.com/knative-extensions/eventing-kafka-broker/releases/download/knative-v"${KNATIVE_VERSION}"/eventing-kafka-broker.yaml
+    oc -n knative-eventing adm policy add-scc-to-user nonroot-v2 -z knative-kafka-broker-data-plane
+    oc patch cm kafka-broker-config -n knative-eventing \
+    --type merge \
+    -p '
+    {
+        "data": {
+        "default.topic.replication.factor": "'"${KAFKA_REPLICATION_FACTOR}"'"
+        }
+    }'
+
+    oc wait --for condition=ready=true pod -l app=kafka-broker-receiver -n knative-eventing --timeout=60s
+
+    echo "Creating broker..."
+    echo "apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+      # case-sensitive
+      eventing.knative.dev/broker.class: Kafka
+  name: ${BROKER_NAME}
+  namespace: ${BROKER_NAMESPACE}
+spec:
+  # Configuration specific to this broker.
+  config:
+      apiVersion: v1
+      kind: ConfigMap
+      name: kafka-broker-config
+      namespace: knative-eventing" | oc apply -f -
+else
+    echo "Using in-memory broker"
+    echo "apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+    name: ${BROKER_NAME}
+    namespace: ${BROKER_NAMESPACE}" | oc apply -f -
+fi
+
+
+echo "Updating SonataflowPlatform to set the eventing spec"
+
+oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type merge \
+   -p '
+{
+  "spec": {
+    "eventing": {
+      "broker": {
+        "ref": {
+          "apiVersion": "eventing.knative.dev/v1",
+          "kind": "Broker",
+          "name": "'"${BROKER_NAME}"'",
+          "namespace": "'"${BROKER_NAMESPACE}"'"
+          }            
+        }
+      }
+    }
+  }'
+
+echo "Restarting Job service and data index deployments"
+oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=0
+oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=0
+
+oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=1
+oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=1

--- a/docs/release-1.5/existing-rhdh.md
+++ b/docs/release-1.5/existing-rhdh.md
@@ -1,0 +1,347 @@
+# Prerequisites
+- RHDH 1.5 instance deployed with IDP configured (github, gitlab, ...)
+- For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.5.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
+- A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
+
+# Installation steps
+
+## Install the Orchestrator Operator
+In 1.5, the Orchestrator infrastructure is installed using the Orchestrator Operator.
+1. Install the Orchestrator Operator 1.5 from OperatorHub.
+1. Create orchestrator resource (operand) instance - ensure `rhdh: installOperator: False` is set, e.g.
+   > Note: `${TARGET_NAMESPACE}` should be set to the desired namespace
+
+    ```yaml
+    apiVersion: rhdh.redhat.com/v1alpha3
+    kind: Orchestrator
+    metadata:
+      name: orchestrator-sample
+      namespace: ${TARGET_NAMESPACE}    # Replace with desired namespace
+    spec:
+      platform:
+        namespace: sonataflow-infra
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+             cpu: 250m
+             memory: 64Mi
+      postgres:
+        authSecret:
+          name: sonataflow-psql-postgresql
+          passwordKey: postgres-password
+          userKey: postgres-username
+        database: sonataflow
+        name: sonataflow-psql-postgresql
+        namespace: sonataflow-infra
+      rhdh:
+        installOperator: false
+    ```
+1. Verify resources and wait until they are running
+    1. From the console run the following command in order to get the necessary wait commands: \
+       `oc describe orchestrator orchestrator-sample -n ${TARGET_NAMESPACE} | grep -A 10 "Run the following commands to wait until the services are ready:"`
+
+       The command will return an output similar to the one below, which lists several oc wait commands. This depends on your specific cluster.
+       ```bash
+         oc wait -n openshift-serverless deploy/knative-openshift --for=condition=Available --timeout=5m
+         oc wait -n knative-eventing knativeeventing/knative-eventing --for=condition=Ready --timeout=5m
+         oc wait -n knative-serving knativeserving/knative-serving --for=condition=Ready --timeout=5m
+         oc wait -n openshift-serverless-logic deploy/logic-operator-rhel8-controller-manager --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra sonataflowplatform/sonataflow-platform --for=condition=Succeed --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-data-index-service --for=condition=Available --timeout=5m
+         oc wait -n sonataflow-infra deploy/sonataflow-platform-jobs-service --for=condition=Available --timeout=5m
+         oc get networkpolicy -n sonataflow-infra
+         ```
+    1. Copy and execute each command from the output in your terminal. These commands ensure that all necessary services and resources in your OpenShift environment are available and running correctly.
+    1. If any service does not become available, verify the logs for that service or consult [troubleshooting steps](https://www.rhdhorchestrator.io/main/docs/serverless-workflows/troubleshooting/).
+
+## Edit RHDH configuration
+As part of RHDH deployed resources, there are two primary ConfigMaps that require modification, typically found under the *rhdh-operator* namespace, or located in the same namespace as the Backstage CR.
+Before enabling the Orchestrator and Notifications plugins, please ensure that a secret that points to the target npmjs registry exists in the same RHDH namespace, e.g.:
+```
+cat <<EOF | oc apply -n $RHDH_NAMESPACE -f -
+apiVersion: v1
+data:
+  .npmrc: cmVnaXN0cnk9aHR0cHM6Ly9ucG0ucmVnaXN0cnkucmVkaGF0LmNvbQo=
+kind: Secret
+metadata:
+  name: dynamic-plugins-npmrc
+EOF
+```
+The value of `.data.npmrc` in the above example points to https://npm.registry.redhat.com. It should be included to consume plugins referenced in this document. If including plugins
+from a different NPM registry, the `.data.npmrc` value should be updated with the base64 encoded NPM registry. Example: https://registry.npmjs.org would be `aHR0cHM6Ly9yZWdpc3RyeS5ucG1qcy5vcmcK`.
+
+If there is a need to point to multiple registries, modify the content of the secret's data from:
+
+```yaml
+  stringData:
+    .npmrc: |
+      registry=https://npm.registry.redhat.com
+```
+to
+```yaml
+  stringData:
+    .npmrc: |
+      @redhat:registry=https://npm.registry.redhat.com
+      @<other-scope>:registry=<other-registry>
+```
+
+### Proxy configuration
+
+If you configured a proxy in your RHDH instance then you need to edit the `NO_PROXY` configuration. You need to add the namespaces where the workflows are deployed and also the namespace `sonataflow-infra`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,`.my-workflow-names
+pace`. Note the `.` before the namespace name.
+
+### dynamic-plugins ConfigMap
+This ConfigMap houses the configuration for enabling and configuring dynamic plugins in RHDH.
+
+To incorporate the Orchestrator plugins, append the following configuration to the **dynamic-plugins** ConfigMap:
+
+- Be sure to review [this section](#identify-latest-supported-plugin-versions) to determine the latest supported Orchestrator plugin `package:` and `integrity:` values, and update the dynamic-plugin ConfigMap entries accordingly. The samples in this document may not reflect the latest.
+- Additionally, ensure that the `dataIndexService.url` in the below configuration points to the service of the Data Index installed by the Orchestrator Operator.
+  By default it should point to `http://sonataflow-platform-data-index-service.sonataflow-infra`. Confirm the service by running this command:
+  ```bash
+  oc get svc -n sonataflow-infra sonataflow-platform-data-index-service -o jsonpath='http://{.metadata.name}.{.metadata.namespace}'
+  ```
+```yaml
+      - disabled: false
+        package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1"
+        integrity: sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==
+        pluginConfig:
+          orchestrator:
+            dataIndexService:
+              url: http://sonataflow-platform-data-index-service.sonataflow-infra
+      - disabled: false
+        package: "@redhat/backstage-plugin-orchestrator@1.5.1"
+        integrity: sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==
+        pluginConfig:
+          dynamicPlugins:
+            frontend:
+              red-hat-developer-hub.backstage-plugin-orchestrator:
+                appIcons:
+                  - importName: OrchestratorIcon
+                    module: OrchestratorPlugin
+                    name: orchestratorIcon
+                dynamicRoutes:
+                  - importName: OrchestratorPage
+                    menuItem:
+                      icon: orchestratorIcon
+                      text: Orchestrator
+                    module: OrchestratorPlugin
+                    path: /orchestrator
+      - disabled: false
+        package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
+        integrity: sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==  
+        pluginConfig:
+          orchestrator:
+            dataIndexService:
+              url: http://sonataflow-platform-data-index-service.sonataflow-infra
+```
+
+To include the Notification Plugin append this configuration to the ConfigMap:
+- Be sure to review [this section](#identify-latest-supported-plugin-versions) to determine the latest supported Orchestrator plugin `package:` and `integrity:` values, and update the dynamic-plugin ConfigMap entries accordingly. The samples in this document may not reflect the latest.
+```yaml
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-signals"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-dynamic"
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-signals-backend-dynamic"
+```
+
+Optionally, include the `plugin-notifications-backend-module-email-dynamic` to fan-out notifications as emails.
+The environment variables below need to be provided to the RHDH instance (Or set the values directly in the ConfigMap).
+See more configuration options for the plugin [here](https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/config.d.ts).
+```yaml
+      - disabled: false
+        package: "./dynamic-plugins/dist/backstage-plugin-notifications-backend-module-email-dynamic"
+        pluginConfig:
+          notifications:
+            processors:
+              email:
+                transportConfig:
+                  transport: smtp
+                  hostname: ${NOTIFICATIONS_EMAIL_HOSTNAME}   # Use value or make variable accessible to Backstage
+                  port: 587
+                  secure: false
+                  username: ${NOTIFICATIONS_EMAIL_USERNAME}   # Use value or make variable accessible to Backstage
+                  password: ${NOTIFICATIONS_EMAIL_PASSWORD}   # Use value or make variable accessible to Backstage
+                sender: sender@mycompany.com
+                replyTo: no-reply@mycompany.com
+                broadcastConfig:
+                  receiver: "none"
+                concurrencyLimit: 10
+                cache:
+                  ttl:
+                    days: 1
+```
+
+Include ArgoCD and Tekton Plugins if using OpenShift Gitops (ArgoCD) and OpenShift Pipelines (Tekton) for Orchestrator Workflows
+```yaml
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-tekton
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-community-plugin-redhat-argocd
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-backstage-plugin-argo-cd-backend-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/roadiehq-scaffolder-backend-argocd-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes-backend-dynamic
+        pluginConfig:
+          kubernetes:
+            clusterLocatorMethods:
+            - clusters:
+              - authProvider: serviceAccount
+                name: Default Cluster
+                serviceAccountToken: ${K8S_CLUSTER_TOKEN}
+                skipTLSVerify: true
+                url: ${K8S_CLUSTER_URL}
+              type: config
+            customResources:
+            - apiVersion: v1
+              group: tekton.dev
+              plural: pipelines
+            - apiVersion: v1
+              group: tekton.dev
+              plural: pipelineruns
+            - apiVersion: v1
+              group: tekton.dev
+              plural: taskruns
+            - apiVersion: v1
+              group: route.openshift.io
+              plural: routes
+            serviceLocatorMethod:
+              type: multiTenant
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-kubernetes
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
+      - disabled: false
+        package: ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-gitlab-dynamic
+```
+
+### app-config ConfigMap
+This ConfigMap is used for configuring backstage. Please add/modify to include the following:
+- `${BACKEND_SECRET}` A static access token to enable the workflows to send notifications to RHDH (As described in the example below) or to invoke scaffolder actions (Or a different method based on this [doc](https://backstage.io/docs/auth/service-to-service-auth/)).
+- A static access token can be generated with this command `node -p 'require("crypto").randomBytes(24).toString("base64")'`
+- `${RHDH_ROUTE}` can be determined by running `oc get route -A -l app.kubernetes.io/name=backstage`
+- Define csp and cors
+- The `guest` provider is used in this example because backstage requires at least one provider to start (It is not required for Orchestrator). The guest provider should only be used for development purposes.
+```yaml
+    auth:
+      environment: development
+      providers:
+        guest:
+          dangerouslyAllowOutsideDevelopment: true
+    backend:
+      auth:
+        externalAccess:
+          - type: static
+            options:
+              token: ${BACKEND_SECRET} # Use value or make variable accessible to Backstage
+              subject: orchestrator
+          - type: legacy
+            options:
+              subject: legacy-default-config
+              secret: "pl4s3Ch4ng3M3"
+      baseUrl: https://${RHDH_ROUTE} # Use value or make variable accessible to Backstage
+      csp:
+        script-src: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+        script-src-elem: ["'self'", "'unsafe-inline'", "'unsafe-eval'"]
+        connect-src: ["'self'", 'http:', 'https:', 'data:']
+      cors:
+        origin: https://${RHDH_ROUTE} # Use value or make variable accessible to Backstage
+      # Include the database configuration if using the notifications plugin
+      database:
+        client: pg
+        connection:
+          password: ${POSTGRESQL_ADMIN_PASSWORD}
+          user: ${POSTGRES_USER}
+          host: ${POSTGRES_HOST}
+          port: ${POSTGRES_PORT}
+```
+> Note: `${BACKEND_SECRET}` and `${RHDH_ROUTE}` variables are not by default accessible by Backstage, so the values should be used directly in the ConfigMap or made accessible to Backstage.
+The `${POSTGRES_*}` variables *are* accessible by default, so they can be left in variable form.
+
+### Import Orchestrator's software templates
+Orchestrator software templates rely on the following tools:
+- Github or GitLab as the git repository system
+- Quay is the image registry
+- GitOps tools are OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton)
+
+To import the Orchestrator software templates into the catalog via the Backstage UI, follow the instructions outlined in this [document](https://backstage.io/docs/features/software-templates/adding-templates).
+Register new templates into the catalog from the
+- Software templates for GitHub:
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/advanced-workflow/template.yaml)
+    - [Convert workflow template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/github-workflows/convert-workflow-to-template/template.yaml)
+- Software templates for GitLab:
+    - [Basic template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/basic-workflow/template.yaml)
+    - [Advanced template - workflow with custom Java code](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/advanced-workflow/template.yaml)
+    - [Convert workflow template](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/scaffolder-templates/gitlab-workflows/convert-workflow-to-template/template.yaml)
+- [Workflow resources (group and system)](https://github.com/rhdhorchestrator/workflow-software-templates/blob/v1.5.x/entities/workflow-resources.yaml) (optional)
+
+## Plugin Versions
+
+### Identify Latest Supported Plugin Versions
+The versions of the plugins may undergo updates, leading to changes in their integrity values. The default plugin values in the Orchestrator CRD can be referenced to ensure that the latest supported plugin versions and integrity values are being utilized. The Orchestrator CRD default plugins can be identified with this command:
+```bash
+oc get crd orchestrators.rhdh.redhat.com -o json | jq '.metadata.annotations | with_entries(select(.key | startswith("orchestrator")))' 
+```
+
+In the example output below, `orchestrator-backend-dynamic-integrity` is the integrity value and `orchestrator-backend-dynamic-package` is the package name:
+```json
+{
+  "orchestrator-backend-dynamic-integrity": "sha512-VIenFStdq9QvvmgmEMG8O7b2wqIebvEcqNeJ9SWZ8jen9t+efTK6D3Rde74LQ1no1QaHLx8RoxNCOuTUEF8O/g==",
+  "orchestrator-backend-dynamic-package": "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.1",
+  "orchestrator-integrity": "sha512-7VOe+XGTUzrdO/av0DNHbydOjB3Lo+XdCs6fj3JVODLP7Ypd3GXHf/nssYxG5ZYC9F1t9MNeguE2bZOB6ckqTA==",
+  "orchestrator-package": "@redhat/backstage-plugin-orchestrator@1.5.1",
+  "orchestrator-scaffolder-backend-integrity": "sha512-bnVQjVsUZ470Vgm2kd5Lo/bVa2fF0q4GufBDc/8oTQsnP3zZJQqKFvFElBTCjY76RqkECydlvZ1UFybSzvockQ==",
+  "orchestrator-scaffolder-backend-package": "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.1"
+}
+```
+> Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0`)
+
+### Upgrade plugin versions - WIP
+To perform an upgrade of the plugin versions, start by acquiring the new plugin version along with its associated integrity value.
+The following script is useful to obtain the required information for updating the plugin version, however, make sure to select plugin version compatible with the Orchestrator operator version (e.g. 1.5.x for both operator and plugins).
+
+> Note: It is recommended to use the Orchestrator Operator default plugins
+
+```bash
+#!/bin/bash
+
+PLUGINS=(
+  "@redhat/backstage-plugin-orchestrator"
+  "@redhat/backstage-plugin-orchestrator-backend-dynamic"
+  "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic"
+)
+
+for PLUGIN_NAME in "${PLUGINS[@]}"
+do
+     echo "Retrieving latest version for plugin: $PLUGIN_NAME\n";
+     curl -s -q "https://npm.registry.redhat.com/${PLUGIN_NAME}/" | jq -r '.versions | keys_unsorted[-1] as $latest_version | .[$latest_version] | "package: \"\(.name)@\(.version)\"\nintegrity: \(.dist.integrity)"';
+     echo "---"
+done
+```
+
+A sample output should look like:
+```
+Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator\n
+package: "@redhat/backstage-plugin-orchestrator@1.5.0"
+integrity: sha512-TmG54OazZLSuzPFmqQSi11koChBE+T8q0ZA7zVkSZZHZjkxvXy2fjqi4Vozz/2hYDUuXRXMJFJ806ijlsiwUsw==
+---
+Retrieving latest version for plugin: @redhat/backstage-plugin-orchestrator-backend-dynamic\n
+package: "@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0"
+integrity: sha512-k+oXawNBQa0TFskAoYvExWZ/EOJ9H4s2+y4ujE+RFzsu7rkm4YmElDIrVYMZhJLRqBhSoHgCdGyn7nSPW20rcg==
+---
+Retrieving latest version for plugin: @redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic\n
+package: "@redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.5.0"
+integrity: sha512-vBosJHdFdgN1FaVjRRBdjQ41rSRBsAAlX+6eD0F2DAAgkjLfERp2SMNHhSV3q18QIGqxJ03KZeX7uPypyw+qVA==
+---
+```
+
+After editing the version and integrity values in the *dynamic-plugins* ConfigMap, the RHDH instance will be restarted automatically.

--- a/docs/release-1.5/existing-rhdh.md
+++ b/docs/release-1.5/existing-rhdh.md
@@ -1,5 +1,5 @@
 # Prerequisites
-- RHDH 1.5 instance deployed with IDP configured (github, gitlab, ...)
+- RHDH 1.5 instance deployed with IDP configured (GitHub, GitLab, ...)
 - For using the Orchestrator's [software templates](https://github.com/rhdhorchestrator/workflow-software-templates/tree/v1.5.x), OpenShift GitOps (ArgoCD) and OpenShift Pipelines (Tekton) should be installed and configured in RHDH (to enhance the CI/CD plugins) - [Follow these steps](https://github.com/rhdhorchestrator/orchestrator-go-operator/blob/main/docs/gitops/README.md)
 - A secret in RHDH's namespace named `dynamic-plugins-npmrc` that points to the plugins npm registry (details will be provided below)
 


### PR DESCRIPTION
## Summary by Sourcery

Add documentation for Orchestrator Release 1.5, including installation guide, existing RHDH configuration, and eventing communication setup

New Features:
- Add documentation for Orchestrator 1.5 release
- Include automated and manual installation scripts for eventing communication
- Provide comprehensive setup guide for Orchestrator plugins in RHDH

Documentation:
- Add comprehensive documentation for Orchestrator Release 1.5, including installation steps, prerequisites, and configuration details
- Include detailed guides for setting up eventing communication using Knative broker
- Provide documentation for configuring Red Hat Developer Hub (RHDH) with Orchestrator plugins