### PR TITLE
Update patch command

### DIFF
--- a/docs/main/README.md
+++ b/docs/main/README.md
@@ -528,14 +528,21 @@ found [here](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.0/
 To fix this issue, please run patch command within the RHDH instance namespace:
 
 ```console
-oc -n <rhdh-namespace> patch deployment <deployment-name> --type='json' -p='[
-  {
-    "op": "add",
-    "path": "/spec/template/spec/initContainers/0/env/-",
-    "value": {
-      "name": "MAX_ENTRY_SIZE",
-      "value": "30000000"
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
+    {
+      "op": "add",
+      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
+      "value": [
+        {
+          "name": "install-dynamic-plugins",
+          "env": [
+            {
+              "name": "MAX_ENTRY_SIZE",
+              "value": "30000000"
+            }
+          ]
+        }
+      ]
     }
-  }
-]'
+  ]'
 ```

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -108,6 +108,8 @@ oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
   ]'
 ```
 
+Find more about this issue [here](https://github.com/rhdhorchestrator/orchestrator-go-operator/tree/main/docs/main#zip-bomb-detected-with-orchestrator-plugin).
+
 ### Proxy configuration
 
 If you configured a proxy in your RHDH instance then you need to edit the `NO_PROXY` configuration. You need to add the namespaces where the workflows are deployed and also the namespace `sonataflow-infra`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,`.my-workflow-names

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -87,6 +87,27 @@ to
       @<other-scope>:registry=<other-registry>
 ```
 
+Edit the Backstage CR to increase the `MAX_ENTRY_SIZE` since the Orchestrator plugin size exceeds the default:
+```
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
+    {
+      "op": "add",
+      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
+      "value": [
+        {
+          "name": "install-dynamic-plugins",
+          "env": [
+            {
+              "name": "MAX_ENTRY_SIZE",
+              "value": "30000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]'
+```
+
 ### Proxy configuration
 
 If you configured a proxy in your RHDH instance then you need to edit the `NO_PROXY` configuration. You need to add the namespaces where the workflows are deployed and also the namespace `sonataflow-infra`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,`.my-workflow-names

--- a/docs/release-1.5/README.md
+++ b/docs/release-1.5/README.md
@@ -527,14 +527,21 @@ found [here](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.0/
 To fix this issue, please run patch command within the RHDH instance namespace:
 
 ```console
-oc -n <rhdh-namespace> patch deployment <deployment-name> --type='json' -p='[
-  {
-    "op": "add",
-    "path": "/spec/template/spec/initContainers/0/env/-",
-    "value": {
-      "name": "MAX_ENTRY_SIZE",
-      "value": "30000000"
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
+    {
+      "op": "add",
+      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
+      "value": [
+        {
+          "name": "install-dynamic-plugins",
+          "env": [
+            {
+              "name": "MAX_ENTRY_SIZE",
+              "value": "30000000"
+            }
+          ]
+        }
+      ]
     }
-  }
-]'
+  ]'
 ```

--- a/docs/release-1.5/existing-rhdh.md
+++ b/docs/release-1.5/existing-rhdh.md
@@ -91,6 +91,29 @@ to
       registry=<global registry>
 ```
 
+Edit the Backstage CR to increase the `MAX_ENTRY_SIZE` since the Orchestraotr plugin size exceeds the default.
+The following value should be sufficient:
+```
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
+    {
+      "op": "add",
+      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
+      "value": [
+        {
+          "name": "install-dynamic-plugins",
+          "env": [
+            {
+              "name": "MAX_ENTRY_SIZE",
+              "value": "30000000"
+            }
+          ]
+        }
+      ]
+    }
+  ]'
+
+```
+
 ### Proxy configuration
 
 If you configured a proxy in your RHDH instance then you need to edit the `NO_PROXY` configuration. You need to add the namespaces where the workflows are deployed and also the namespace `sonataflow-infra`. E.g. NO_PROXY=current-value-of-no-proxy, `.sonataflow-infra`,`.my-workflow-names

--- a/docs/release-1.5/existing-rhdh.md
+++ b/docs/release-1.5/existing-rhdh.md
@@ -91,8 +91,7 @@ to
       registry=<global registry>
 ```
 
-Edit the Backstage CR to increase the `MAX_ENTRY_SIZE` since the Orchestraotr plugin size exceeds the default.
-The following value should be sufficient:
+Edit the Backstage CR to increase the `MAX_ENTRY_SIZE` since the Orchestrator plugin size exceeds the default:
 ```
 oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
     {
@@ -112,6 +111,7 @@ oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
     }
   ]'
 ```
+Find more about this issue [here](https://github.com/rhdhorchestrator/orchestrator-go-operator/tree/main/docs/release-1.5#zip-bomb-detected-with-orchestrator-plugin).
 
 ### Proxy configuration
 

--- a/docs/release-1.5/existing-rhdh.md
+++ b/docs/release-1.5/existing-rhdh.md
@@ -111,7 +111,6 @@ oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
       ]
     }
   ]'
-
 ```
 
 ### Proxy configuration


### PR DESCRIPTION
## Summary by Sourcery

Update documentation for Red Hat Developer Hub (RHDH) patch configuration, specifically addressing Orchestrator plugin size limitations

Documentation:
- Add instructions for patching Backstage Custom Resource to increase MAX_ENTRY_SIZE for Orchestrator plugin
- Update proxy configuration guidance to include additional namespaces in NO_PROXY setting