### PR TITLE
Update Go Version

### DIFF
--- a/.tekton/controller-rhel9-operator-on-pull-request-1-6.yaml
+++ b/.tekton/controller-rhel9-operator-on-pull-request-1-6.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "internal/***".pathChanged() || ".tekton/controller-rhel9-operator-on-pull-request-1-6.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main" && ("Makefile".pathChanged() || "konflux.Dockerfile".pathChanged() || "config/***".pathChanged() || "internal/***".pathChanged() || ".tekton/controller-rhel9-operator-on-pull-request-1-6.yaml".pathChanged() || "go.mod".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator-1-6

--- a/.tekton/controller-rhel9-operator-on-push-1-6.yaml
+++ b/.tekton/controller-rhel9-operator-on-push-1-6.yaml
@@ -6,7 +6,7 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("Makefile".pathChanged() || "Dockerfile".pathChanged() || "config/***".pathChanged() || "internal/***".pathChanged() || ".tekton/controller-rhel9-operator-on-push-1-6.yaml".pathChanged())
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" && ("Makefile".pathChanged() || "konflux.Dockerfile".pathChanged() || "config/***".pathChanged() || "internal/***".pathChanged() || ".tekton/controller-rhel9-operator-on-push-1-6.yaml".pathChanged() || "go.mod".pathChanged())
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: operator-1-6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rhdhorchestrator/orchestrator-operator
 
-go 1.22.7
+go 1.23
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.2


### PR DESCRIPTION
## Summary by Sourcery

Update the project to use Go 1.23.

Build:
- Update the builder image in the Dockerfile to `golang:1.23`.
- Update the Go version directive in `go.mod` to `1.23`.

CI:
- Configure Tekton pipelines to trigger on changes to `go.mod`.
- Update Tekton pipeline triggers to monitor `konflux.Dockerfile` instead of `Dockerfile`.