### PR TITLE
Fixing no match Kind error in Orchestrator CR when rhdh is disabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -19,15 +19,16 @@ package controller
 import (
 	"context"
 	"fmt"
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"strings"
 	"time"
 
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	knative "github.com/rhdhorchestrator/orchestrator-operator/internal/controller/knative"
 	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/kube"
 	"github.com/rhdhorchestrator/orchestrator-operator/internal/controller/rhdh"
-	knative "github.com/rhdhorchestrator/orchestrator-operator/internal/controller/knative"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
@@ -191,7 +192,7 @@ func (r *OrchestratorReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// handle RHDH
 	rhdhConfig := orchestrator.Spec.RHDHConfig
 	if err := r.reconcileRHDH(ctx, serverlessWorkflowNamespace, argoCDEnabled, tektonEnabled, rhdhConfig); err != nil {
-		if apierrors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
 			return ctrl.Result{Requeue: true, RequeueAfter: RequeueAfterTime}, nil
 		}
 		logger.Error(err, "Error occurred when creating RHDH resources")


### PR DESCRIPTION
This PR closes https://issues.redhat.com/browse/FLPATH-2315, 
backstage handler needed to exclude a different error to avoid failing the Orchestrator CR when rhdh was disabled. 
Also golang version bump after some package bumps needed it

## Summary by Sourcery

Modify Orchestrator CR handling to prevent failures when Red Hat Developer Hub (RHDH) is disabled by handling no match kind errors

Bug Fixes:
- Fixed Orchestrator CR reconciliation to handle no match kind errors when RHDH is disabled

Enhancements:
- Updated error handling in RHDH reconciliation to improve resilience

Chores:
- Bumped Golang version from 1.22 to 1.23 in Dockerfile