### PR TITLE
Fix strimzi link in eventing install script

### DIFF
--- a/docs/main/eventing-communication/eventing-automate-install.sh
+++ b/docs/main/eventing-communication/eventing-automate-install.sh
@@ -69,7 +69,7 @@ if [ "$INSTALL_KAFKA_CLUSTER" == true ]; then
     echo "Installing a kafka cluster using Strimzi default quickstart: https://strimzi.io/quickstarts/"
     oc create namespace kafka
     oc create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
-    oc apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n kafka 
+    oc apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n kafka 
     oc wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka 
     KAFKA_REPLICATION_FACTOR=1
 fi

--- a/docs/release-1.5/eventing-communication/eventing-automate-install.sh
+++ b/docs/release-1.5/eventing-communication/eventing-automate-install.sh
@@ -69,7 +69,7 @@ if [ "$INSTALL_KAFKA_CLUSTER" == true ]; then
     echo "Installing a kafka cluster using Strimzi default quickstart: https://strimzi.io/quickstarts/"
     oc create namespace kafka
     oc create -f 'https://strimzi.io/install/latest?namespace=kafka' -n kafka
-    oc apply -f https://strimzi.io/examples/latest/kafka/kraft/kafka-single-node.yaml -n kafka 
+    oc apply -f https://strimzi.io/examples/latest/kafka/kafka-single-node.yaml -n kafka 
     oc wait kafka/my-cluster --for=condition=Ready --timeout=300s -n kafka 
     KAFKA_REPLICATION_FACTOR=1
 fi


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/FLPATH-2313
Fix strimzi link in eventing install script

## Summary by Sourcery

Bug Fixes:
- Correct the Strimzi Kafka single-node manifest URL in the automated install scripts for both main and release-1.5 branches.