### PR TITLE
ubi-image bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1747218906
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Use redhat ubi9 as minimal base image to package the manager binary
 # https://registry.access.redhat.com/ubi9/ubi-minimal
-FROM registry.access.redhat.com/ubi9-minimal:9.5-1742914212
+FROM registry.access.redhat.com/ubi9-minimal:9.6-1747218906
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
For fixing CVE issue - now PR on main

## Summary by Sourcery

Bump UBI base image version to address a CVE

Enhancements:
- Update ubi9-minimal base image from 9.5-1742914212 to 9.6-1747218906 in Dockerfile
- Update ubi9-minimal base image from 9.5-1742914212 to 9.6-1747218906 in konflux.Dockerfile