### PR TITLE
Update backstage CR patch command for the zip bomb fix

### DIFF
--- a/docs/main/README.md
+++ b/docs/main/README.md
@@ -528,21 +528,29 @@ found [here](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.0/
 To fix this issue, please run patch command within the RHDH instance namespace:
 
 ```console
-oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
-    {
-      "op": "add",
-      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
-      "value": [
-        {
-          "name": "install-dynamic-plugins",
-          "env": [
-            {
-              "name": "MAX_ENTRY_SIZE",
-              "value": "30000000"
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type=merge -p '{
+    "spec": {
+      "deployment": {
+        "patch": {
+          "spec": {
+            "template": {
+              "spec": {
+                "initContainers": [
+                  {
+                    "name": "install-dynamic-plugins",
+                    "env": [
+                      {
+                        "name": "MAX_ENTRY_SIZE",
+                        "value": "30000000"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
-          ]
+          }
         }
-      ]
+      }
     }
-  ]'
+  }'
 ```

--- a/docs/release-1.5/README.md
+++ b/docs/release-1.5/README.md
@@ -527,21 +527,29 @@ found [here](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.0/
 To fix this issue, please run patch command within the RHDH instance namespace:
 
 ```console
-oc -n <rhdh-namespace> patch backstage <rhdh-name> --type='json' -p='[
-    {
-      "op": "add",
-      "path": "/spec/deployment/patch/spec/template/spec/initContainers",
-      "value": [
-        {
-          "name": "install-dynamic-plugins",
-          "env": [
-            {
-              "name": "MAX_ENTRY_SIZE",
-              "value": "30000000"
+oc -n <rhdh-namespace> patch backstage <rhdh-name> --type=merge -p '{
+    "spec": {
+      "deployment": {
+        "patch": {
+          "spec": {
+            "template": {
+              "spec": {
+                "initContainers": [
+                  {
+                    "name": "install-dynamic-plugins",
+                    "env": [
+                      {
+                        "name": "MAX_ENTRY_SIZE",
+                        "value": "30000000"
+                      }
+                    ]
+                  }
+                ]
+              }
             }
-          ]
+          }
         }
-      ]
+      }
     }
-  ]'
+  }'
 ```


### PR DESCRIPTION
## Summary by Sourcery

Update documentation for patching the Backstage custom resource to apply the zip bomb fix using a merge patch instead of a JSON patch.

Enhancements:
- Switch the patch command in main README to use --type=merge with a JSON merge payload.
- Apply the same update to the release-1.5 README to align instructions across versions.