### PR TITLE
Patch Implementation for Zip Bomb Issue

### DIFF
--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-05-21T10:37:53Z"
+    createdAt: "2025-05-27T01:16:17Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -220,6 +220,7 @@ spec:
           - get
           - list
           - patch
+          - update
           - watch
         - apiGroups:
           - rhdh.redhat.com

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -111,6 +111,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - rhdh.redhat.com

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -261,8 +261,7 @@ func (r *OrchestratorReconciler) reconcileServerlessLogic(
 	// check if install operator is disabled and handle clean up if necessary
 	if !serverlessLogicOperator.InstallOperator {
 		sfLogger.Info("Operator is disabled. Handle Clean up process if necessary")
-		// handle clean up
-		return handleServerlessLogicCleanUp(ctx, r.Client, serverlessWorkflowNamespace)
+		return nil
 	}
 	// Subscription is enabled; check namespace exist
 	if _, err := kube.CheckNamespaceExist(ctx, r.Client, serverlessWorkflowNamespace); err != nil {
@@ -308,10 +307,7 @@ func (r *OrchestratorReconciler) reconcileKnative(ctx context.Context, serverles
 
 	// if subscription is disabled; check if subscription exists and handle delete
 	if !serverlessOperator.InstallOperator {
-		// handle cleanup
-		if err := knative.HandleKnativeCleanUp(ctx, r.Client); err != nil {
-			return err
-		}
+		knativeLogger.Info("Operator is disabled. Handle Clean up process if necessary")
 		return nil
 	}
 
@@ -338,15 +334,11 @@ func (r *OrchestratorReconciler) reconcileRHDH(
 	logger := log.FromContext(ctx)
 	logger.Info("Starting Reconciliation for RHDH")
 
-	subscriptionName := rhdhConfig.Name
 	namespace := rhdhConfig.Namespace
 
 	// if install operator is disabled; handle clean up
 	if !rhdhConfig.InstallOperator {
-		if err := rhdh.HandleRHDHCleanUp(ctx, r.Client, namespace); err != nil {
-			logger.Error(err, "Error occurred when cleaning up RHDH", "SubscriptionName", subscriptionName)
-			return err
-		}
+		logger.Info("Operator is disabled. Handle Clean up process if necessary")
 		return nil
 	}
 

--- a/internal/controller/orchestrator_controller.go
+++ b/internal/controller/orchestrator_controller.go
@@ -78,7 +78,7 @@ type OrchestratorReconciler struct {
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions;operatorgroups;clusterserviceversions;catalogsources;installplans,verbs=get;list;watch;create;delete;patch;update
 //+kubebuilder:rbac:groups=sonataflow.org,resources=sonataflows;sonataflowclusterplatforms;sonataflowplatforms,verbs=get;list;watch;create;delete;patch;update
 //+kubebuilder:rbac:groups=operator.knative.dev,resources=knativeeventings;knativeservings,verbs=get;list;watch;create;delete;patch;update
-//+kubebuilder:rbac:groups=rhdh.redhat.com,resources=backstages,verbs=get;list;create;delete;patch;watch
+//+kubebuilder:rbac:groups=rhdh.redhat.com,resources=backstages,verbs=get;list;create;delete;patch;watch;update
 //+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=tekton.dev,resources=pipelines,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/rhdh/BackstagePatchSpec.go
+++ b/internal/controller/rhdh/BackstagePatchSpec.go
@@ -1,0 +1,21 @@
+package rhdh
+
+type ContainerEnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type InitContainer struct {
+	Name string            `json:"name"`
+	Env  []ContainerEnvVar `json:"env"`
+}
+
+type PatchSpec struct {
+	Spec struct {
+		Template struct {
+			Spec struct {
+				InitContainers []InitContainer `json:"initContainers"`
+			} `json:"spec"`
+		} `json:"template"`
+	} `json:"spec"`
+}

--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -322,23 +322,13 @@ func getPatchObjectForBackstageCR(ctx context.Context) ([]byte, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Creating Deployment Patch Object for Backstage CR...")
 
-	patch := make(map[string]interface{})
-
-	spec := util.ValidateMap(patch, "spec")
-	template := util.ValidateMap(spec, "template")
-	templateSpec := util.ValidateMap(template, "spec")
-	initContainers, _ := templateSpec["initContainers"].([]interface{})
-
-	initContainers = append(initContainers, map[string]interface{}{
-		"name": "install-dynamic-plugins",
-		"env": []interface{}{
-			map[string]interface{}{
-				"name":  "MAX_ENTRY_SIZE",
-				"value": "30000000",
-			},
+	patch := PatchSpec{}
+	patch.Spec.Template.Spec.InitContainers = append(patch.Spec.Template.Spec.InitContainers, InitContainer{
+		Name: "install-dynamic-plugins",
+		Env: []ContainerEnvVar{
+			{Name: "MAX_ENTRY_SIZE", Value: "30000000"},
 		},
 	})
-	templateSpec["initContainers"] = initContainers
 
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {

--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -332,10 +332,7 @@ func patchBackstageInitContainer(ctx context.Context, rhdhName, rhdhNamespace st
 	spec := util.ValidateMap(patch, "spec")
 	template := util.ValidateMap(spec, "template")
 	templateSpec := util.ValidateMap(template, "spec")
-	initContainers, ok := templateSpec["initContainers"].([]interface{})
-	if !ok {
-		initContainers = []interface{}{}
-	}
+	initContainers, _ := templateSpec["initContainers"].([]interface{})
 
 	// find "install-dynamic-plugins" container
 	for i, c := range initContainers {
@@ -343,9 +340,7 @@ func patchBackstageInitContainer(ctx context.Context, rhdhName, rhdhNamespace st
 		if !ok {
 			continue
 		}
-		logger.Info("Current Init Container value", "initContainer", container)
 		if container["name"] == "install-dynamic-plugins" {
-			logger.Info("Current ENV value", "ENV", container)
 			envList := util.ValidateSlice(container, "env")
 			container["env"] = append(envList, map[string]interface{}{
 				"name":  "MAX_ENTRY_SIZE",

--- a/internal/controller/util/helper.go
+++ b/internal/controller/util/helper.go
@@ -4,25 +4,3 @@ package util
 func MakePointer[T any](t T) *T {
 	return &t
 }
-
-// ValidateMap Helper to ensure nested map[string]interface{} structure
-func ValidateMap(m map[string]interface{}, key string) map[string]interface{} {
-	if val, ok := m[key]; ok {
-		if cast, ok := val.(map[string]interface{}); ok {
-			return cast
-		}
-	}
-	newMap := make(map[string]interface{})
-	m[key] = newMap
-	return newMap
-}
-
-// ValidateSlice Helper to ensure nested []interface{} structure
-func ValidateSlice(m map[string]interface{}, key string) []interface{} {
-	if val, ok := m[key]; ok {
-		if cast, ok := val.([]interface{}); ok {
-			return cast
-		}
-	}
-	return []interface{}{}
-}

--- a/internal/controller/util/helper.go
+++ b/internal/controller/util/helper.go
@@ -4,3 +4,25 @@ package util
 func MakePointer[T any](t T) *T {
 	return &t
 }
+
+// ValidateMap Helper to ensure nested map[string]interface{} structure
+func ValidateMap(m map[string]interface{}, key string) map[string]interface{} {
+	if val, ok := m[key]; ok {
+		if cast, ok := val.(map[string]interface{}); ok {
+			return cast
+		}
+	}
+	newMap := make(map[string]interface{})
+	m[key] = newMap
+	return newMap
+}
+
+// ValidateSlice Helper to ensure nested []interface{} structure
+func ValidateSlice(m map[string]interface{}, key string) []interface{} {
+	if val, ok := m[key]; ok {
+		if cast, ok := val.([]interface{}); ok {
+			return cast
+		}
+	}
+	return []interface{}{}
+}


### PR DESCRIPTION
## Summary by Sourcery

Patch Backstage CRs to inject a maximum entry size limit into the init container to address zip bomb risks, streamline disabled-operator cleanup logic, and update RBAC permissions and helpers.

New Features:
- Inject MAX_ENTRY_SIZE environment variable into the Backstage init container via a new patchBackstageInitContainer function

Bug Fixes:
- Mitigate zip bomb vulnerability by capping entry size in the dynamic plugins installer

Enhancements:
- Simplify cleanup branches in OrchestratorReconciler to log and return immediately when operators are disabled
- Introduce util.ValidateMap and util.ValidateSlice helpers for safe nested map/slice operations

Chores:
- Add ‘update’ verb to Backstage RBAC rules in code annotations, CSV, and role.yaml
- Bump CSV createdAt timestamp