### PR TITLE
Bumping Knative 1.5.1, RHDH 1.6,  OSL 1.36 with RC workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0-rc1
+VERSION ?= 1.6.0-rc3
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-05-28T08:29:30Z"
+    createdAt: "2025-05-29T07:39:32Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-05-27T01:16:17Z"
+    createdAt: "2025-05-28T08:29:30Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.0-rc1
+  name: orchestrator-operator.v1.6.0-rc3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc1
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.0-rc1
+  version: 1.6.0-rc3

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.0-rc1
+  newTag: 1.6.0-rc3

--- a/internal/controller/knative.go
+++ b/internal/controller/knative.go
@@ -41,7 +41,7 @@ const (
 	knativeSubscriptionName        = "serverless-operator"
 	knativeOperatorNamespace       = "openshift-serverless"
 	knativeSubscriptionChannel     = "stable"
-	knativeSubscriptionStartingCSV = "serverless-operator.v1.35.0"
+	knativeSubscriptionStartingCSV = "serverless-operator.v1.35.1"
 )
 
 func handleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {

--- a/internal/controller/knative/knative.go
+++ b/internal/controller/knative/knative.go
@@ -42,7 +42,7 @@ const (
 	KnativeSubscriptionName        = "serverless-operator"
 	KnativeOperatorNamespace       = "openshift-serverless"
 	KnativeSubscriptionChannel     = "stable"
-	KnativeSubscriptionStartingCSV = "serverless-operator.v1.35.0"
+	KnativeSubscriptionStartingCSV = "serverless-operator.v1.35.1"
 )
 
 func HandleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -175,9 +175,16 @@ func getOperatorGroup(ctx context.Context, client client.Client,
 	return nil
 }
 
-func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV string) *v1alpha1.Subscription {
+func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV string, extraCatalogSourceNames ...string) *v1alpha1.Subscription {
 	logger := log.Log.WithName("subscriptionObject")
 	logger.Info("Creating subscription object")
+
+	SourceName := CatalogSourceName
+
+	// Override default source with custom source name, from paramaters
+	if len(extraCatalogSourceNames) > 0 {
+		SourceName = extraCatalogSourceNames[0]
+	}
 
 	subscriptionObject := &v1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
@@ -188,7 +195,7 @@ func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV 
 		Spec: &v1alpha1.SubscriptionSpec{
 			Channel:                channel,
 			InstallPlanApproval:    v1alpha1.ApprovalManual,
-			CatalogSource:          CatalogSourceName,
+			CatalogSource:          SourceName,
 			StartingCSV:            startingCSV,
 			CatalogSourceNamespace: CatalogSourceNamespace,
 			Package:                subscriptionName,

--- a/internal/controller/rhdh/backstage.go
+++ b/internal/controller/rhdh/backstage.go
@@ -28,7 +28,7 @@ const (
 	rhdhSubscriptionName              = "rhdh"
 	rhdhSubscriptionChannel           = "fast-1.6"
 	rhdhOperatorNamespace             = "rhdh-operator"
-	rhdhSubscriptionStartingCSV       = "rhdh-operator.v1.6.0"
+	rhdhSubscriptionStartingCSV       = "rhdh-operator.v1.6.1"
 )
 
 var ConfigMapNameAndConfigDataKey = map[string]string{

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -50,6 +50,7 @@ const (
 	knativeBrokerAPIVersion                = "eventing.knative.dev/v1"
 	knativeBrokerKind                      = "Broker"
 	sonataFlowPlatformReference            = "sonataflow-platform"
+	CatalogSourceNameSonataFlow            = "logic-136-cr1" // Remove after Sonataflow Release
 )
 
 // handleServerlessLogicOperatorInstallation performs operator installation for the OSL operand
@@ -73,7 +74,8 @@ func handleServerlessLogicOperatorInstallation(ctx context.Context, client clien
 		serverlessLogicSubscriptionName,
 		serverlessLogicOperatorNamespace,
 		serverlessLogicSubscriptionChannel,
-		serverlessLogicSubscriptionStartingCSV)
+		serverlessLogicSubscriptionStartingCSV,
+		CatalogSourceNameSonataFlow)
 
 	subscriptionExists, existingSubscription, err := kube.CheckSubscriptionExists(ctx, olmClientSet, oslSubscription)
 	if err != nil {

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -46,7 +46,7 @@ const (
 	serverlessLogicSubscriptionChannel     = "alpha"
 	serverlessLogicOperatorNamespace       = "openshift-serverless-logic"
 	serverlessLogicSubscriptionName        = "logic-operator-rhel8"
-	serverlessLogicSubscriptionStartingCSV = "logic-operator-rhel8.v1.35.0"
+	serverlessLogicSubscriptionStartingCSV = "logic-operator-rhel8.v1.36.0"
 	knativeBrokerAPIVersion                = "eventing.knative.dev/v1"
 	knativeBrokerKind                      = "Broker"
 	sonataFlowPlatformReference            = "sonataflow-platform"


### PR DESCRIPTION
This PR includes bumping OSL to 1.36

## Summary by Sourcery

Bump orchestrator-go-operator to v1.6.0-rc3 and upgrade SonataFlow serverless logic subscription to v1.36.0.

Enhancements:
- Update orchestrator operator to version v1.6.0-rc3 across CSV metadata, Makefile, kustomization, and deployment manifests
- Refresh CSV createdAt timestamp to the latest build time
- Upgrade SonataFlow serverless logic subscription starting CSV to logic-operator-rhel8.v1.36.0