### PR TITLE
Update OSL 36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0-rc4
+VERSION ?= 1.6.0-rc5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-06-16T13:59:01Z"
+    createdAt: "2025-06-16T14:54:08Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.0-rc4
+  name: orchestrator-operator.v1.6.0-rc5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc4
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.0-rc4
+  version: 1.6.0-rc5

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.0-rc4
+  newTag: 1.6.0-rc5

--- a/internal/controller/kube/kube_operations.go
+++ b/internal/controller/kube/kube_operations.go
@@ -175,16 +175,11 @@ func getOperatorGroup(ctx context.Context, client client.Client,
 	return nil
 }
 
-func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV string, extraCatalogSourceNames ...string) *v1alpha1.Subscription {
+func CreateSubscriptionObject(subscriptionName, namespace, channel, startingCSV string) *v1alpha1.Subscription {
 	logger := log.Log.WithName("subscriptionObject")
 	logger.Info("Creating subscription object")
 
 	SourceName := CatalogSourceName
-
-	// Override default source with custom source name, from paramaters
-	if len(extraCatalogSourceNames) > 0 {
-		SourceName = extraCatalogSourceNames[0]
-	}
 
 	subscriptionObject := &v1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/sonataflow.go
+++ b/internal/controller/sonataflow.go
@@ -50,7 +50,6 @@ const (
 	knativeBrokerAPIVersion                = "eventing.knative.dev/v1"
 	knativeBrokerKind                      = "Broker"
 	sonataFlowPlatformReference            = "sonataflow-platform"
-	CatalogSourceNameSonataFlow            = "logic-136-cr1" // Remove after Sonataflow Release
 )
 
 // handleServerlessLogicOperatorInstallation performs operator installation for the OSL operand
@@ -75,7 +74,7 @@ func handleServerlessLogicOperatorInstallation(ctx context.Context, client clien
 		serverlessLogicOperatorNamespace,
 		serverlessLogicSubscriptionChannel,
 		serverlessLogicSubscriptionStartingCSV,
-		CatalogSourceNameSonataFlow)
+	)
 
 	subscriptionExists, existingSubscription, err := kube.CheckSubscriptionExists(ctx, olmClientSet, oslSubscription)
 	if err != nil {


### PR DESCRIPTION
## Summary by Sourcery

Update release candidate version to 1.6.0-rc5 and remove obsolete catalog source override logic

Enhancements:
- Bump operator version to v1.6.0-rc5 across manifest CSV, bundle metadata, container image tag, Makefile and kustomization configuration
- Remove extraCatalogSourceNames parameter handling from CreateSubscriptionObject and clean up related CatalogSourceNameSonataFlow constant
- Update CSV creation timestamp to reflect new build iteration