### PR TITLE
Adding WORKLFOW_NAMESPACE param to eventing script + readme

### DIFF
--- a/docs/main/eventing-communication/README.md
+++ b/docs/main/eventing-communication/README.md
@@ -31,6 +31,7 @@ Usage:
 Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] ./eventing-automate-install.sh
   ORCHESTRATOR_NAME                   Name of the installed orchestrator CR
   ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators
+  WORKFLOW_NAMESPACE                  Namespace in which the workflows are deployed"
   BROKER_NAME                         Name of the broker to install
   BROKER_NAMESPACE                    Namespace in which the broker must be installed
   BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'
@@ -41,6 +42,7 @@ Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESP
 #### With pre-existing Kafka cluster
 ```console
 ORCHESTRATOR_NAME=orchestrator-sample \
+WORKFLOW_NAMESPACE=sonataflow-infra \
 BROKER_NAME=kafka-broker \
 BROKER_NAMESPACE=sonataflow-infra \
 INSTALL_KAFKA_CLUSTER=false \
@@ -49,6 +51,7 @@ KAFKA_REPLICATION_FACTOR=1 ./eventing-automate-install.sh
 #### Without existing Kafka cluster
 ```console
 ORCHESTRATOR_NAME=orchestrator-sample \
+WORKFLOW_NAMESPACE=sonataflow-infra \
 BROKER_NAME=kafka-broker \
 BROKER_NAMESPACE=sonataflow-infra \
 INSTALL_KAFKA_CLUSTER=true ./eventing-automate-install.sh
@@ -57,6 +60,7 @@ INSTALL_KAFKA_CLUSTER=true ./eventing-automate-install.sh
 ```console
 BROKER_TYPE=in-memory \
 ORCHESTRATOR_NAME=orchestrator-sample \
+WORKFLOW_NAMESPACE=sonataflow-infra \
 BROKER_NAME=simple-broker \
 BROKER_NAMESPACE=sonataflow-infra ./eventing-automate-install.sh
 ```
@@ -146,7 +150,7 @@ metadata:
 1. Configure the `sonataflowplatform` with your Broker's information. 
 
 ```console
-oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type merge \
+oc -n ${WORKFLOW_NAMESPACE} patch sonataflowplatform sonataflow-platform --type merge \
    -p '
 {
   "spec": {
@@ -166,13 +170,13 @@ oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type m
 Scale the Job service and data index service deployments:
 
 ```console
-oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=0
+oc scale deployment sonataflow-platform-jobs-service -n ${WORKFLOW_NAMESPACE} --replicas=0
 
-oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=0
+oc scale deployment sonataflow-platform-data-index-service -n ${WORKFLOW_NAMESPACE} --replicas=0
 
-oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=1
+oc scale deployment sonataflow-platform-jobs-service -n ${WORKFLOW_NAMESPACE} --replicas=1
 
-oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=1
+oc scale deployment sonataflow-platform-data-index-service -n ${WORKFLOW_NAMESPACE} --replicas=1
 ```
 
 The `sinkbinding` and `trigger` resources should be automatically created by the OpenShift Serverless Logic operator:

--- a/docs/main/eventing-communication/README.md
+++ b/docs/main/eventing-communication/README.md
@@ -31,7 +31,7 @@ Usage:
 Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [WORKFLOW_NAMESPACE=sonataflow-infra] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] ./eventing-automate-install.sh
   ORCHESTRATOR_NAME                   Name of the installed orchestrator CR
   ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators
-  WORKFLOW_NAMESPACE                  Namespace in which the workflows are deployed
+  WORKFLOW_NAMESPACE                  Optional, namespace in which the workflows are deployed. Default is sonataflow-infra
   BROKER_NAME                         Name of the broker to install
   BROKER_NAMESPACE                    Namespace in which the broker must be installed
   BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'

--- a/docs/main/eventing-communication/README.md
+++ b/docs/main/eventing-communication/README.md
@@ -28,10 +28,10 @@ You can follow an automated or a manual approach:
 ## Automated installation steps
 Usage:
 ```
-Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] ./eventing-automate-install.sh
+Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [WORKFLOW_NAMESPACE=sonataflow-infra] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] ./eventing-automate-install.sh
   ORCHESTRATOR_NAME                   Name of the installed orchestrator CR
   ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators
-  WORKFLOW_NAMESPACE                  Namespace in which the workflows are deployed"
+  WORKFLOW_NAMESPACE                  Namespace in which the workflows are deployed
   BROKER_NAME                         Name of the broker to install
   BROKER_NAMESPACE                    Namespace in which the broker must be installed
   BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'

--- a/docs/main/eventing-communication/eventing-automate-install.sh
+++ b/docs/main/eventing-communication/eventing-automate-install.sh
@@ -10,7 +10,7 @@ function usage {
     echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [WORKFLOW_NAMESPACE=sonataflow-infra] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
     echo "  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR"
     echo "  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators"
-    echo "  WORKFLOW_NAMESPACE                  Optional, Namespace in which the workflows are deployed
+    echo "  WORKFLOW_NAMESPACE                  Optional, namespace in which the workflows are deployed. Default is sonataflow-infra
     echo "  BROKER_NAME                         Name of the broker to install"
     echo "  BROKER_NAMESPACE                    Namespace in which the broker must be installed"
     echo "  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'"

--- a/docs/main/eventing-communication/eventing-automate-install.sh
+++ b/docs/main/eventing-communication/eventing-automate-install.sh
@@ -7,9 +7,10 @@ program_name=$0
 KNATIVE_VERSION=1.15.8
 
 function usage {
-    echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
+    echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [WORKFLOW_NAMESPACE=sonataflow-infra] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
     echo "  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR"
     echo "  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators"
+    echo "  WORKFLOW_NAMESPACE                  Optional, Namespace in which the workflows are deployed"
     echo "  BROKER_NAME                         Name of the broker to install"
     echo "  BROKER_NAMESPACE                    Namespace in which the broker must be installed"
     echo "  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'"
@@ -31,6 +32,10 @@ fi
 
 if [[ -z "${ORCHESTRATOR_NAMESPACE}" ]]; then
   ORCHESTRATOR_NAMESPACE=openshift-operators
+fi
+
+if [[ -z "${WORKFLOW_NAMESPACE}" ]]; then
+  WORKFLOW_NAMESPACE=sonataflow-infra
 fi
 
 if [[ -z "${ORCHESTRATOR_NAME}" ]]; then
@@ -124,7 +129,7 @@ fi
 
 echo "Updating SonataflowPlatform to set the eventing spec"
 
-oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type merge \
+oc -n ${WORKFLOW_NAMESPACE} patch sonataflowplatform sonataflow-platform --type merge \
    -p '
 {
   "spec": {
@@ -142,8 +147,8 @@ oc -n <workflow-namespace> patch sonataflowplatform sonataflow-platform --type m
   }'
 
 echo "Restarting Job service and data index deployments"
-oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=0
-oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=0
+oc scale deployment sonataflow-platform-jobs-service -n ${WORKFLOW_NAMESPACE} --replicas=0
+oc scale deployment sonataflow-platform-data-index-service -n ${WORKFLOW_NAMESPACE} --replicas=0
 
-oc scale deployment sonataflow-platform-jobs-service -n <workflow-namespace> --replicas=1
-oc scale deployment sonataflow-platform-data-index-service -n <workflow-namespace> --replicas=1
+oc scale deployment sonataflow-platform-jobs-service -n ${WORKFLOW_NAMESPACE} --replicas=1
+oc scale deployment sonataflow-platform-data-index-service -n ${WORKFLOW_NAMESPACE} --replicas=1

--- a/docs/main/eventing-communication/eventing-automate-install.sh
+++ b/docs/main/eventing-communication/eventing-automate-install.sh
@@ -10,7 +10,7 @@ function usage {
     echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [WORKFLOW_NAMESPACE=sonataflow-infra] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
     echo "  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR"
     echo "  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators"
-    echo "  WORKFLOW_NAMESPACE                  Optional, Namespace in which the workflows are deployed"
+    echo "  WORKFLOW_NAMESPACE                  Optional, Namespace in which the workflows are deployed
     echo "  BROKER_NAME                         Name of the broker to install"
     echo "  BROKER_NAMESPACE                    Namespace in which the broker must be installed"
     echo "  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'"


### PR DESCRIPTION
This PR will fix the following bug: https://issues.redhat.com/browse/FLPATH-2413

## Summary by Sourcery

Add WORKFLOW_NAMESPACE parameter to the eventing install script and reference it in documentation, replacing hardcoded namespace placeholders

Bug Fixes:
- Fix FLPATH-2413 by restoring workflow namespace handling in the eventing automation script

Enhancements:
- Introduce WORKFLOW_NAMESPACE env var with a default value and use it in patch and scale commands instead of hardcoded placeholders

Documentation:
- Update eventing README to document the new WORKFLOW_NAMESPACE parameter in usage examples