### PR TITLE
Update Serverless to 1.36 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0-rc5
+VERSION ?= 1.6.0-rc6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-06-16T15:07:41Z"
+    createdAt: "2025-06-19T03:47:22Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.0-rc5
+  name: orchestrator-operator.v1.6.0-rc6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc5
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc6
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.0-rc5
+  version: 1.6.0-rc6

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.0-rc5
+  newTag: 1.6.0-rc6

--- a/internal/controller/knative/knative.go
+++ b/internal/controller/knative/knative.go
@@ -42,7 +42,7 @@ const (
 	KnativeSubscriptionName        = "serverless-operator"
 	KnativeOperatorNamespace       = "openshift-serverless"
 	KnativeSubscriptionChannel     = "stable"
-	KnativeSubscriptionStartingCSV = "serverless-operator.v1.35.1"
+	KnativeSubscriptionStartingCSV = "serverless-operator.v1.36.0"
 )
 
 func HandleKNativeOperatorInstallation(ctx context.Context, client client.Client, olmClientSet olmclientset.Interface) error {


### PR DESCRIPTION
## Summary by Sourcery

Bump Serverless to v1.36 and update orchestrator operator to v1.6.0-rc6 across manifests and configs

Enhancements:
- Update ClusterServiceVersion metadata, CSV name, image references, and bundle version to 1.6.0-rc6
- Update Makefile default VERSION and Kustomize controller image tag to 1.6.0-rc6
- Bump Knative subscription starting CSV to serverless-operator.v1.36.0