### PR TITLE
updated plugins to RC1.6.0-13, operator to RC9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0-rc8
+VERSION ?= 1.6.0-rc9
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,14 +239,14 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
-// +kubebuilder:metadata:annotations=orchestrator-package=backstage-plugin-orchestrator-1.6.0-rc.13.tgz
-// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
-// +kubebuilder:metadata:annotations=orchestrator-form-widgets-package=backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz
-// +kubebuilder:metadata:annotations=orchestrator-form-widgets-integrity=sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
+// +kubebuilder:metadata:annotations=orchestrator-package=backstage-plugin-orchestrator-1.6.0-rc.14.tgz
+// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==
+// +kubebuilder:metadata:annotations=orchestrator-form-widgets-package=backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz
+// +kubebuilder:metadata:annotations=orchestrator-form-widgets-integrity=sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-06-25T12:36:21Z"
+    createdAt: "2025-06-26T09:13:06Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.0-rc8
+  name: orchestrator-operator.v1.6.0-rc9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc8
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc9
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.0-rc8
+  version: 1.6.0-rc9

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -3,14 +3,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
-    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz
-    orchestrator-form-widgets-integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
-    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz
-    orchestrator-integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
-    orchestrator-package: backstage-plugin-orchestrator-1.6.0-rc.13.tgz
-    orchestrator-scaffolder-backend-integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
-    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz
+    orchestrator-backend-dynamic-integrity: sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==
+    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz
+    orchestrator-form-widgets-integrity: sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==
+    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz
+    orchestrator-integrity: sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==
+    orchestrator-package: backstage-plugin-orchestrator-1.6.0-rc.14.tgz
+    orchestrator-scaffolder-backend-integrity: sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==
+    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -4,14 +4,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
-    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz
-    orchestrator-form-widgets-integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
-    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz
-    orchestrator-integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
-    orchestrator-package: backstage-plugin-orchestrator-1.6.0-rc.13.tgz
-    orchestrator-scaffolder-backend-integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
-    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz
+    orchestrator-backend-dynamic-integrity: sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==
+    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz
+    orchestrator-form-widgets-integrity: sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==
+    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz
+    orchestrator-integrity: sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==
+    orchestrator-package: backstage-plugin-orchestrator-1.6.0-rc.14.tgz
+    orchestrator-scaffolder-backend-integrity: sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==
+    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.0-rc8
+  newTag: 1.6.0-rc9

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -134,15 +134,15 @@ To incorporate the Orchestrator plugins, append the following configuration to t
   ```
 ```yaml
     - disabled: false
-      integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
-      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13/backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz
+      integrity: sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==
+      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14/backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz
       pluginConfig:
         orchestrator:
           dataIndexService:
             url: http://sonataflow-platform-data-index-service.sonataflow-infra
     - disabled: false
-      integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
-      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13/backstage-plugin-orchestrator-1.6.0-rc.13.tgz
+      integrity: sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==
+      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14/backstage-plugin-orchestrator-1.6.0-rc.14.tgz
       pluginConfig:
         dynamicPlugins:
           frontend:
@@ -157,16 +157,16 @@ To incorporate the Orchestrator plugins, append the following configuration to t
                   text: Orchestrator
                 path: /orchestrator
     - disabled: false
-      integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
-      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz
+      integrity: sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==
+      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz
       pluginConfig:
         dynamicPlugins:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service.sonataflow-infra
     - disabled: false
-      integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
-      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13/backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz
+      integrity: sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==
+      package: https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14/backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz
       pluginConfig:
         dynamicPlugins:
           frontend:
@@ -332,14 +332,14 @@ In the example output below, `orchestrator-backend-dynamic-integrity` is the int
 ```json
 {
 {
-  "orchestrator-package": "backstage-plugin-orchestrator-1.6.0-rc.13.tgz",
-  "orchestrator-integrity": "sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==",
-  "orchestrator-backend-dynamic-package": "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz",
-  "orchestrator-backend-dynamic-integrity": "sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==",
-  "orchestrator-scaffolder-backend-package": "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz",
-  "orchestrator-scaffolder-backend-integrity": "sha512-4F563LxlAzGakDx4J63szF0i8YyO6ZVRz0i9Bp/Qessdp1E+zlRCgyIqHWSgQGUopzVzNrT20LmHQUzosH0naw==",
-  "orchestrator-form-widgets-package": "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz",
-  "orchestrator-form-widgets-integrity": "sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w=="
+  "orchestrator-package": "backstage-plugin-orchestrator-1.6.0-rc.14.tgz",
+  "orchestrator-integrity": "sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==",
+  "orchestrator-backend-dynamic-package": "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz",
+  "orchestrator-backend-dynamic-integrity": "sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==",
+  "orchestrator-scaffolder-backend-package": "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz",
+  "orchestrator-scaffolder-backend-integrity": "sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==",
+  "orchestrator-form-widgets-package": "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz",
+  "orchestrator-form-widgets-integrity": "sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g=="
 }
 }
 ```
@@ -371,19 +371,19 @@ done
 A sample output should look like:
 ```
 Retrieving latest version for plugin: backstage-plugin-orchestrator
-package: "backstage-plugin-orchestrator-1.6.0-rc.13.tgz"
+package: "backstage-plugin-orchestrator-1.6.0-rc.14.tgz"
 integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
 ---
 Retrieving latest version for plugin: backstage-plugin-orchestrator-backend-dynamic
-package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz"
+package: "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz"
 integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
 ---
 Retrieving latest version for plugin: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic
-package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz"
+package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz"
 integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
 ---
 Retrieving latest version for plugin: backstage-plugin-orchestrator-form-widgets
-package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz"
+package: "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz"
 integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
 
 

--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -6,6 +6,6 @@ const (
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.registry.redhat.com"
-	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.13"
+	Scope                          = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.0-rc.14"
 	CatalogBranch                  = "v1.6.x"
 )

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -13,20 +13,20 @@ const OrchestratorFormWidgets string = "orchestratorFormWidgets"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.6.0-rc.13.tgz",
-			Integrity: "sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==",
+			Package:   "backstage-plugin-orchestrator-1.6.0-rc.14.tgz",
+			Integrity: "sha512-9gmptRRqrx0cZjThctJJLYCuzPa1av5S9NdAitAFsGvx5KVgVK8VinOKpyHgLbM6cdBDdIne0wdVFaLijxQHjg==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.13.tgz",
-			Integrity: "sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.6.0-rc.14.tgz",
+			Integrity: "sha512-kuN16JcbbPSvBdr0iJRUlwMaXppTir+edpsYQerXzHsZhaU9cEzXEI5tAsUklOb5qSAi9ENeCZTK0jTlp8wUlg==",
 		},
 		ScaffolderBackendOrchestrator: {
-			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.13.tgz",
-			Integrity: "sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==",
+			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.0-rc.14.tgz",
+			Integrity: "sha512-HpP6WFu8xTc2HTg2QLLRCW59nyt4MhFhlww477BUcBwiHzohJipG30b3eT/OcSMaFIMgOaD2dCMlLfxWLab9Qg==",
 		},
 		OrchestratorFormWidgets: {
-			Package:   "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.13.tgz",
-			Integrity: "sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==",
+			Package:   "backstage-plugin-orchestrator-form-widgets-1.6.0-rc.14.tgz",
+			Integrity: "sha512-ZQwbHD7wWQ9ElOetThPLBwbcmpNR8A+S+XLtG9Q2c7EycxA+mgXTtq8GQV1iteavHhCmcmpCriF3lsdLax61+g==",
 		},
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Bump orchestrator plugins to v1.6.0-rc.14 and operator to v1.6.0-rc9 across documentation, code, manifests, and configuration.

Enhancements:
- Update orchestrator plugins package URLs and integrity hashes to v1.6.0-rc.14 in docs, CRDs, and plugin definitions.
- Upgrade operator version from v1.6.0-rc8 to v1.6.0-rc9, including CSV metadata, image tags, Makefile, and kustomization configurations.