### PR TITLE
Orchestrator Operator 1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.0-rc10
+VERSION ?= 1.6.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-06-26T20:42:41Z"
+    createdAt: "2025-06-27T14:00:49Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.0-rc10
+  name: orchestrator-operator.v1.6.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0-rc10
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.0-rc10
+  version: 1.6.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.0-rc10
+  newTag: 1.6.0

--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -5,7 +5,7 @@ const (
 	AppConfigRHDHAuthName          = "app-config-rhdh-auth"
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
-	NpmRegistry                    = "https://npm.stage.registry.redhat.com"
+	NpmRegistry                    = "https://npm.registry.redhat.com"
 	Scope                          = "@redhat"
 	CatalogBranch                  = "v1.6.x"
 )


### PR DESCRIPTION
## Summary by Sourcery

Release orchestrator operator v1.6.0 by updating bundle metadata, image tags, version variables, and switching the NPM registry to the production endpoint.

Enhancements:
- Update cluster service version, image tags, Makefile, and kustomization to reference v1.6.0 instead of v1.6.0-rc10.
- Change NPM registry URL from the staging to the production endpoint.