### PR TITLE
Fix missing quote introduced from FLPATH-2413 fix

### DIFF
--- a/docs/main/eventing-communication/eventing-automate-install.sh
+++ b/docs/main/eventing-communication/eventing-automate-install.sh
@@ -10,7 +10,7 @@ function usage {
     echo -e "Usage: ORCHESTRATOR_NAME=ORCHESTRATOR_NAME BROKER_NAME=BROKER_NAME BROKER_NAMESPACE=BROKER_NAMESPACE [KAFKA_REPLICATION_FACTOR=KAFKA_REPLICATION_FACTOR] [ORCHESTRATOR_NAMESPACE=openshift-operators] [WORKFLOW_NAMESPACE=sonataflow-infra] [BROKER_TYPE=Kafka] [INSTALL_KAFKA_CLUSTER=true] $program_name"
     echo "  ORCHESTRATOR_NAME                   Name of the installed orchestrator CR"
     echo "  ORCHESTRATOR_NAMESPACE              Optional, namespace in which the orchestrator operator is deployed. Default is openshift-operators"
-    echo "  WORKFLOW_NAMESPACE                  Optional, namespace in which the workflows are deployed. Default is sonataflow-infra
+    echo "  WORKFLOW_NAMESPACE                  Optional, namespace in which the workflows are deployed. Default is sonataflow-infra"
     echo "  BROKER_NAME                         Name of the broker to install"
     echo "  BROKER_NAMESPACE                    Namespace in which the broker must be installed"
     echo "  BROKER_TYPE                         Optional , type of the broker. Either 'Kafka' or 'in-memory'. Default is: 'Kafka'"


### PR DESCRIPTION
Fixes a missing quote causing the kafka eventing install script to fail. Quote was introduced in this commit https://github.com/rhdhorchestrator/orchestrator-go-operator/pull/200. 

I tested with the quote added and it works.