### PR TITLE
Add Network Policy

### DIFF
--- a/internal/controller/network_policy_test.go
+++ b/internal/controller/network_policy_test.go
@@ -71,6 +71,20 @@ func TestHandleNetworkPolicy(t *testing.T) {
 						Ingress: []networkingv1.NetworkPolicyIngressRule{},
 					},
 				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      allowServerlessLogicToSonataFlowWorkflows,
+						Namespace: testNamespace,
+						Labels:    kubeoperations.GetOrchestratorLabel(),
+					},
+					Spec: networkingv1.NetworkPolicySpec{
+						PodSelector: metav1.LabelSelector{},
+						PolicyTypes: []networkingv1.PolicyType{
+							networkingv1.PolicyTypeIngress,
+						},
+						Ingress: []networkingv1.NetworkPolicyIngressRule{},
+					},
+				},
 			},
 			monitoringFlag: false,
 			expectCreate:   false,
@@ -96,6 +110,8 @@ func TestHandleNetworkPolicy(t *testing.T) {
 				err := fakeClient.Get(ctx, types.NamespacedName{Name: allowRHDHToSonataflowWorkflows, Namespace: testNamespace}, existingNP)
 				assert.NoError(t, err)
 				err = fakeClient.Get(ctx, types.NamespacedName{Name: allowIntraNamespace, Namespace: testNamespace}, existingNP)
+				assert.NoError(t, err)
+				err = fakeClient.Get(ctx, types.NamespacedName{Name: allowServerlessLogicToSonataFlowWorkflows, Namespace: testNamespace}, existingNP)
 				assert.NoError(t, err)
 
 				if tc.monitoringFlag {
@@ -154,6 +170,11 @@ func TestCreateIngressSwitch(t *testing.T) {
 			name:            "Create Monitoring Ingress",
 			npName:          allowMonitoringToSonataflowWorkflows,
 			expectedIngress: createIngressMonitoringSonataflowWorkflows(),
+		},
+		{
+			name:            "Create Serverless Operator Ingress",
+			npName:          allowServerlessLogicToSonataFlowWorkflows,
+			expectedIngress: createIngressServerlessLogicSonataFlowWorkflows(),
 		},
 		{
 			name:            "Create Non existent Ingress",


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/FLPATH-2610 and https://issues.redhat.com/browse/FLPATH-2613

## Summary by Sourcery

Add a new network policy rule to allow ingress traffic from the OpenShift Serverless Logic namespace to SonataFlow and workflows.

Enhancements:
- Introduce a constant and update the network policy list for allowServerlessLogicToSonataFlowWorkflows
- Implement createIngressServerlessLogicSonataFlowWorkflows to define the NamespaceSelector-based ingress rule
- Add a switch case in createIngress to support the new serverless logic policy

Tests:
- Add handling and retrieval tests for the serverless logic network policy in TestHandleNetworkPolicy
- Add a createIngressServerlessLogicSonataFlowWorkflows test case to TestCreateIngressSwitch