### PR TITLE
Orchestrator Operator 1.6.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.6.1-rc2
+VERSION ?= 1.6.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/api/v1alpha3/orchestrator_types.go
+++ b/api/v1alpha3/orchestrator_types.go
@@ -239,14 +239,14 @@ type OrchestratorStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp",description="Age"
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=".status.phase",description="Status"
-// +kubebuilder:metadata:annotations=orchestrator-package=backstage-plugin-orchestrator-1.6.1-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-TJ58d5CqFcNmvhBPJp+/7nt0gZo4ILqRjE2+9ZHjIVht2X0gCJqqGYF41sTgBotb2biOD024W/5xp2qQzRbaww==
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-qveMcu8jO2KsKzgXioNmmbQKxGUbUloWbDxZfa3sQDSGakB6RSE5kNPTAy1QmCvBqufeOFrfv36LpV7d757SHA==
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-fq5oUIVyigshMUHD5N85937wCLIQVixV+mvVmCjl99FvY7A4/5X11vASHOFx+1cLW7zBZDT5hc3zJlPDBR2zWQ==
-// +kubebuilder:metadata:annotations=orchestrator-form-widgets-package=backstage-plugin-orchestrator-form-widgets-1.6.1-rc.2.tgz
-// +kubebuilder:metadata:annotations=orchestrator-form-widgets-integrity=sha512-1KDZmf+iJUevivLsamiD/wvGhuK9PZeGrPNz5wevFC4eXYHB1Iq+Nugjq1IqBQWKIY3jhAIMwba1ZVz4jlu7/A==
+// +kubebuilder:metadata:annotations=orchestrator-package=backstage-plugin-orchestrator@1.6.1
+// +kubebuilder:metadata:annotations=orchestrator-integrity=sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-package=backstage-plugin-orchestrator-backend-dynamic@1.6.1
+// +kubebuilder:metadata:annotations=orchestrator-backend-dynamic-integrity=sha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-package=backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1
+// +kubebuilder:metadata:annotations=orchestrator-scaffolder-backend-integrity=sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==
+// +kubebuilder:metadata:annotations=orchestrator-form-widgets-package=backstage-plugin-orchestrator-form-widgets@1.6.1
+// +kubebuilder:metadata:annotations=orchestrator-form-widgets-integrity=sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ==
 type Orchestrator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/orchestrator-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-07-21T10:51:46Z"
+    createdAt: "2025-08-15T00:51:04Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
@@ -89,7 +89,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/rhdhorchestrator/orchestrator-go-operator
-  name: orchestrator-operator.v1.6.1-rc2
+  name: orchestrator-operator.v1.6.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -326,7 +326,7 @@ spec:
                 - --health-probe-bind-address=:8081
                 command:
                 - /manager
-                image: quay.io/orchestrator/orchestrator-go-operator:1.6.1-rc2
+                image: quay.io/orchestrator/orchestrator-go-operator:1.6.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -414,4 +414,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.redhat.com
-  version: 1.6.1-rc2
+  version: 1.6.1

--- a/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
+++ b/bundle/manifests/rhdh.redhat.com_orchestrators.yaml
@@ -3,14 +3,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-qveMcu8jO2KsKzgXioNmmbQKxGUbUloWbDxZfa3sQDSGakB6RSE5kNPTAy1QmCvBqufeOFrfv36LpV7d757SHA==
-    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.2.tgz
-    orchestrator-form-widgets-integrity: sha512-1KDZmf+iJUevivLsamiD/wvGhuK9PZeGrPNz5wevFC4eXYHB1Iq+Nugjq1IqBQWKIY3jhAIMwba1ZVz4jlu7/A==
-    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.1-rc.2.tgz
-    orchestrator-integrity: sha512-TJ58d5CqFcNmvhBPJp+/7nt0gZo4ILqRjE2+9ZHjIVht2X0gCJqqGYF41sTgBotb2biOD024W/5xp2qQzRbaww==
-    orchestrator-package: backstage-plugin-orchestrator-1.6.1-rc.2.tgz
-    orchestrator-scaffolder-backend-integrity: sha512-fq5oUIVyigshMUHD5N85937wCLIQVixV+mvVmCjl99FvY7A4/5X11vASHOFx+1cLW7zBZDT5hc3zJlPDBR2zWQ==
-    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.2.tgz
+    orchestrator-backend-dynamic-integrity: sha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==
+    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic@1.6.1
+    orchestrator-form-widgets-integrity: sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ==
+    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets@1.6.1
+    orchestrator-integrity: sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==
+    orchestrator-package: backstage-plugin-orchestrator@1.6.1
+    orchestrator-scaffolder-backend-integrity: sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==
+    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1
   creationTimestamp: null
   name: orchestrators.rhdh.redhat.com
 spec:

--- a/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
+++ b/config/crd/bases/rhdh.redhat.com_orchestrators.yaml
@@ -4,14 +4,14 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.15.0
-    orchestrator-backend-dynamic-integrity: sha512-qveMcu8jO2KsKzgXioNmmbQKxGUbUloWbDxZfa3sQDSGakB6RSE5kNPTAy1QmCvBqufeOFrfv36LpV7d757SHA==
-    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.2.tgz
-    orchestrator-form-widgets-integrity: sha512-1KDZmf+iJUevivLsamiD/wvGhuK9PZeGrPNz5wevFC4eXYHB1Iq+Nugjq1IqBQWKIY3jhAIMwba1ZVz4jlu7/A==
-    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets-1.6.1-rc.2.tgz
-    orchestrator-integrity: sha512-TJ58d5CqFcNmvhBPJp+/7nt0gZo4ILqRjE2+9ZHjIVht2X0gCJqqGYF41sTgBotb2biOD024W/5xp2qQzRbaww==
-    orchestrator-package: backstage-plugin-orchestrator-1.6.1-rc.2.tgz
-    orchestrator-scaffolder-backend-integrity: sha512-fq5oUIVyigshMUHD5N85937wCLIQVixV+mvVmCjl99FvY7A4/5X11vASHOFx+1cLW7zBZDT5hc3zJlPDBR2zWQ==
-    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.2.tgz
+    orchestrator-backend-dynamic-integrity: sha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==
+    orchestrator-backend-dynamic-package: backstage-plugin-orchestrator-backend-dynamic@1.6.1
+    orchestrator-form-widgets-integrity: sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ==
+    orchestrator-form-widgets-package: backstage-plugin-orchestrator-form-widgets@1.6.1
+    orchestrator-integrity: sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==
+    orchestrator-package: backstage-plugin-orchestrator@1.6.1
+    orchestrator-scaffolder-backend-integrity: sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==
+    orchestrator-scaffolder-backend-package: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1
   name: orchestrators.rhdh.redhat.com
 spec:
   group: rhdh.redhat.com

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/orchestrator/orchestrator-go-operator
-  newTag: 1.6.1-rc2
+  newTag: 1.6.1

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -141,15 +141,15 @@ To incorporate the Orchestrator plugins, append the following configuration to t
   ```
 ```yaml
     - disabled: false
-      integrity: sha512-ch4Mn+1oGEeQALJ0RY9dfjNj8QQlU0csWm4Vdsr8nQAdW6QLB6A0cuJxhv7Xpum/NzZgVPhOK6BNmb1dHIFr4g==
-      package: @redhat/backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.1.tgz
+      integrity: ha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==
+      package: @redhat/backstage-plugin-orchestrator-backend-dynamic@1.6.1
       pluginConfig:
         orchestrator:
           dataIndexService:
             url: http://sonataflow-platform-data-index-service.sonataflow-infra
     - disabled: false
-      integrity: sha512-TYFpSbH4qX09Vzm5wyoUoKpjEQ1idej//KXszD8f6jlqduyVj/KndONIhtAxwHtslIopQVNojv7C5oFJs9+AyQ==
-      package: @redhat/backstage-plugin-orchestrator-1.6.1-rc.1.tgz
+      integrity: sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==
+      package: @redhat/backstage-plugin-orchestrator@1.6.1
       pluginConfig:
         dynamicPlugins:
           frontend:
@@ -164,16 +164,16 @@ To incorporate the Orchestrator plugins, append the following configuration to t
                     text: Orchestrator
                   path: /orchestrator
     - disabled: false
-      integrity: sha512-j/81ZK/+sNdBFdrliCX2q7u0HBhhsx2e6ysfcK1/wj1PW3zHeDDB03w/AFvtPbdnEl5Lq0iZtdF9hNHPt6xV/A==
-      package: @redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.1.tgz
+      integrity: sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==
+      package: @redhat/backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1
       pluginConfig:
         dynamicPlugins:
           orchestrator:
             dataIndexService:
               url: http://sonataflow-platform-data-index-service.sonataflow-infra
     - disabled: false
-      integrity: sha512-HasqhJHrY4+fQL9EctC1GQDYkw2mfpL/I//ut5RFBXgNM3+DpCh5DmW8QHAfvzWilfuSFJb3cBOfTrdOoOaDMw==
-      package: @redhat/backstage-plugin-orchestrator-form-widgets-1.6.1-rc.1.tgz
+      integrity: sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ==
+      package: @redhat/backstage-plugin-orchestrator-form-widgets@1.6.1
       pluginConfig:
         dynamicPlugins:
           frontend:
@@ -337,14 +337,14 @@ oc get crd orchestrators.rhdh.redhat.com -o json | jq '.metadata.annotations | w
 In the example output below, `orchestrator-backend-dynamic-integrity` is the integrity value and `orchestrator-backend-dynamic-package` is the package name:
 ```json
 {
-  "orchestrator-package": "backstage-plugin-orchestrator-1.6.1-rc.1.tgz",
-  "orchestrator-integrity": "sha512-TYFpSbH4qX09Vzm5wyoUoKpjEQ1idej//KXszD8f6jlqduyVj/KndONIhtAxwHtslIopQVNojv7C5oFJs9+AyQ==",
-  "orchestrator-backend-dynamic-package": "backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.1.tgz",
-  "orchestrator-backend-dynamic-integrity": "sha512-ch4Mn+1oGEeQALJ0RY9dfjNj8QQlU0csWm4Vdsr8nQAdW6QLB6A0cuJxhv7Xpum/NzZgVPhOK6BNmb1dHIFr4g==",
-  "orchestrator-scaffolder-backend-package": "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.1.tgz",
-  "orchestrator-scaffolder-backend-integrity": "sha512-j/81ZK/+sNdBFdrliCX2q7u0HBhhsx2e6ysfcK1/wj1PW3zHeDDB03w/AFvtPbdnEl5Lq0iZtdF9hNHPt6xV/A==",
-  "orchestrator-form-widgets-package": "backstage-plugin-orchestrator-form-widgets-1.6.1-rc.1.tgz",
-  "orchestrator-form-widgets-integrity": "sha512-HasqhJHrY4+fQL9EctC1GQDYkw2mfpL/I//ut5RFBXgNM3+DpCh5DmW8QHAfvzWilfuSFJb3cBOfTrdOoOaDMw=="
+  "orchestrator-package": "backstage-plugin-orchestrator@1.6.1",
+  "orchestrator-integrity": "sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==",
+  "orchestrator-backend-dynamic-package": "backstage-plugin-orchestrator-backend-dynamic@1.6.1",
+  "orchestrator-backend-dynamic-integrity": "ha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==",
+  "orchestrator-scaffolder-backend-package": "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1",
+  "orchestrator-scaffolder-backend-integrity": "sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==",
+  "orchestrator-form-widgets-package": "backstage-plugin-orchestrator-form-widgets@1.6.1",
+  "orchestrator-form-widgets-integrity": "sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ=="
 }
 ```
 > Note: The Orchestrator plugin package names in the `dynamic-plugins` ConfigMap must have `@redhat/` prepended to the package name (i.e., `@redhat/backstage-plugin-orchestrator-backend-dynamic@1.5.0`)
@@ -375,19 +375,19 @@ done
 A sample output should look like:
 ```
 Retrieving latest version for plugin: backstage-plugin-orchestrator
-package: "backstage-plugin-orchestrator-1.6.1-rc.1.tgz"
+package: "backstage-plugin-orchestrator@1.6.1"
 integrity: sha512-8hG2rviqBzzEVRhbHdyZxRZBPLV2fbsDhmTqZSbB6Yt9fDvKNZ/WIaoDGcMmv4cUcmfI3ozTdd5935/1RJG/nA==
 ---
 Retrieving latest version for plugin: backstage-plugin-orchestrator-backend-dynamic
-package: "backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.1.tgz"
+package: "backstage-plugin-orchestrator-backend-dynamic@1.6.1"
 integrity: sha512-bnfDpTa3snJMByumIGOSt0iuT0kQEAA7w9lLY1SrLm++3maWFUw6zAe70DQsT7qv1d+gx6pXCdmyTAxk8L+4dw==
 ---
 Retrieving latest version for plugin: backstage-plugin-scaffolder-backend-module-orchestrator-dynamic
-package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.1.tgz"
+package: "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1"
 integrity: sha512-2ocAxZYxsymLzVNe2ebiD1b9/TxJZyh7TYDcM6PeC1G416Mqf8QJZMuHh44hfBpdDkRRK8qRrVEDOAfDC2J5sA==
 ---
 Retrieving latest version for plugin: backstage-plugin-orchestrator-form-widgets
-package: "backstage-plugin-orchestrator-form-widgets-1.6.1-rc.1.tgz"
+package: "backstage-plugin-orchestrator-form-widgets@1.6.1"
 integrity: sha512-F49J8XOql9TPlETzqy5ll0XHM4HZiWQbEzM8RsOdMTaMh6FNoTR04LATFDYTi/gQg4PC5qT8W7wSxH7gH/Gj3w==
 
 

--- a/docs/main/existing-rhdh.md
+++ b/docs/main/existing-rhdh.md
@@ -340,7 +340,7 @@ In the example output below, `orchestrator-backend-dynamic-integrity` is the int
   "orchestrator-package": "backstage-plugin-orchestrator@1.6.1",
   "orchestrator-integrity": "sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==",
   "orchestrator-backend-dynamic-package": "backstage-plugin-orchestrator-backend-dynamic@1.6.1",
-  "orchestrator-backend-dynamic-integrity": "ha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==",
+  "orchestrator-backend-dynamic-integrity": "sha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==",
   "orchestrator-scaffolder-backend-package": "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1",
   "orchestrator-scaffolder-backend-integrity": "sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==",
   "orchestrator-form-widgets-package": "backstage-plugin-orchestrator-form-widgets@1.6.1",

--- a/internal/controller/rhdh/configmap_ref.go
+++ b/internal/controller/rhdh/configmap_ref.go
@@ -6,7 +6,6 @@ const (
 	AppConfigRHDHCatalogName       = "app-config-rhdh-catalog"
 	AppConfigRHDHDynamicPluginName = "dynamic-plugins-rhdh"
 	NpmRegistry                    = "https://npm.registry.redhat.com"
-	//Scope                          = "@redhat" // for production
-	Scope         = "https://github.com/rhdhorchestrator/orchestrator-plugins-internal-release/releases/download/v1.6.1-rc.2"
-	CatalogBranch = "v1.6.x"
+	Scope                          = "@redhat"
+	CatalogBranch                  = "v1.6.x"
 )

--- a/internal/controller/rhdh/plugins.go
+++ b/internal/controller/rhdh/plugins.go
@@ -13,20 +13,20 @@ const OrchestratorFormWidgets string = "orchestratorFormWidgets"
 func getPlugins() map[string]Plugin {
 	return map[string]Plugin{
 		Orchestrator: {
-			Package:   "backstage-plugin-orchestrator-1.6.1-rc.2.tgz",
-			Integrity: "sha512-TJ58d5CqFcNmvhBPJp+/7nt0gZo4ILqRjE2+9ZHjIVht2X0gCJqqGYF41sTgBotb2biOD024W/5xp2qQzRbaww==",
+			Package:   "backstage-plugin-orchestrator@1.6.1",
+			Integrity: "sha512-6qQ/TLvrf4+gDhrF5JtKQ51hTrNkhEw0jE4lWvLmhauZKeD0EeJVYOlbAvDJZjmx7iJZXLFFydR6EnYuaHBZ+A==",
 		},
 		OrchestratorBackend: {
-			Package:   "backstage-plugin-orchestrator-backend-dynamic-1.6.1-rc.2.tgz",
-			Integrity: "sha512-qveMcu8jO2KsKzgXioNmmbQKxGUbUloWbDxZfa3sQDSGakB6RSE5kNPTAy1QmCvBqufeOFrfv36LpV7d757SHA==",
+			Package:   "backstage-plugin-orchestrator-backend-dynamic@1.6.1",
+			Integrity: "sha512-oAHyLnLWzPMeCuUCc2syuG1bJ+7say7n+AjXu/oEi2t59ULCKI6zFpBSy0GvXd7zoBC9ruW/slhEG+APKmTQUg==",
 		},
 		ScaffolderBackendOrchestrator: {
-			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic-1.6.1-rc.2.tgz",
-			Integrity: "sha512-fq5oUIVyigshMUHD5N85937wCLIQVixV+mvVmCjl99FvY7A4/5X11vASHOFx+1cLW7zBZDT5hc3zJlPDBR2zWQ==",
+			Package:   "backstage-plugin-scaffolder-backend-module-orchestrator-dynamic@1.6.1",
+			Integrity: "sha512-FPd9bZZhlnYqPej4gCWR1eXaGOPouticrufd8kvHNwfJcO3eRCzPr5yC9E9tbEqyzvZvQBDfljcBeswORhIqfQ==",
 		},
 		OrchestratorFormWidgets: {
-			Package:   "backstage-plugin-orchestrator-form-widgets-1.6.1-rc.2.tgz",
-			Integrity: "sha512-1KDZmf+iJUevivLsamiD/wvGhuK9PZeGrPNz5wevFC4eXYHB1Iq+Nugjq1IqBQWKIY3jhAIMwba1ZVz4jlu7/A==",
+			Package:   "backstage-plugin-orchestrator-form-widgets@1.6.1",
+			Integrity: "sha512-jWuawuAxVo7DDSX26t+L4DPhCxR8cpl3AMvUQnWKejzj2/1GwL/FHfffQwa2sSF2xtOKfkAJwnv5p4/5ocjcaQ==",
 		},
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Bump Orchestrator Operator and plugin packages from 1.6.1-rc to stable 1.6.1

Enhancements:
- Update all package names to use @redhat scope with version 1.6.1 and refresh integrity hashes
- Revise CRD metadata, ClusterServiceVersion, configmap, Makefile, and kustomization to reflect the 1.6.1 release and image tags