### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for orchestrator-operator-bundle-1-6

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -17,7 +17,8 @@ LABEL controller="registry.redhat.io/rhdh-orchestrator-dev-preview-beta/controll
 # Required labels
 LABEL com.redhat.component="RHDH Orchestrator Operator"
 LABEL distribution-scope="public"
-LABEL name="rhdh-orchestrator-go-operator-bundle"
+LABEL name="rhdh-orchestrator-dev-preview-beta/orchestrator-operator-bundle"
+LABEL cpe="cpe:/a:redhat:rhdh:1.6::el9"
 LABEL release="1.6.1"
 LABEL version="1.6.1"
 LABEL maintainer="Red Hat jubah@redhat.com"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini

## Summary by Sourcery

Set correct image name label and add CPE label in the orchestrator operator bundle Dockerfile to support vulnerability lookups.

Chores:
- Update the name label to use the dev-preview-beta path for orchestrator-operator-bundle
- Add a CPE label for RH DH version 1.6 on EL9